### PR TITLE
Centralize build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+ls -fi *.sln -rec | % {  dotnet build $_.FullName }

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <MicrosoftMLVersion>0.2.0-preview-26530-3</MicrosoftMLVersion>
+  </PropertyGroup>
+
+</Project>

--- a/samples/end-to-end-apps/github-labeler/GitHubLabeler/GitHubLabeler.csproj
+++ b/samples/end-to-end-apps/github-labeler/GitHubLabeler/GitHubLabeler.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.1.0" />
+    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0-rc1" />
   </ItemGroup>

--- a/samples/getting-started/BinaryClassification_SentimentAnalysis/BinaryClassification_SentimentAnalysis.csproj
+++ b/samples/getting-started/BinaryClassification_SentimentAnalysis/BinaryClassification_SentimentAnalysis.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.2.0-preview-26530-3" />
+    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/getting-started/MulticlassClassification_Iris/MulticlassClassification_Iris.csproj
+++ b/samples/getting-started/MulticlassClassification_Iris/MulticlassClassification_Iris.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.2.0-preview-26530-3" />
+    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/getting-started/Regression_TaxiFarePrediction/Regression_TaxiFarePrediction.csproj
+++ b/samples/getting-started/Regression_TaxiFarePrediction/Regression_TaxiFarePrediction.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.2.0-preview-26530-3" />
+    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/nuget.config
+++ b/samples/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Dailies" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This adds a `build.ps1` that builds all projects in the repo. It also adds props file that centralizes the version number of the ML.NET package that should be used. It currently also adds a nuget.config that inlcudes our nightlies so that we can test against the latest API in case we have to.