### PR TITLE
Upgraded Reggression_BikeSharingDemands sample to v0.3 of vNext globally specified

### DIFF
--- a/samples/examples/Reggression_BikeSharingDemands/BikeSharingDemand/BikeSharingDemand.csproj
+++ b/samples/examples/Reggression_BikeSharingDemands/BikeSharingDemand/BikeSharingDemand.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.2.0" />
+    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" /> 
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded Reggression_BikeSharingDemands sample to ML.NET v0.3 or any version which is globally specified with $(MicrosoftMLVersion) from the global Directory.Build.props file.