### PR TITLE
Fix Broken Image in Regression_TaxiFarePrediction README.md

### DIFF
--- a/samples/csharp/getting-started/Regression_TaxiFarePrediction/README.md
+++ b/samples/csharp/getting-started/Regression_TaxiFarePrediction/README.md
@@ -25,7 +25,7 @@ The common feature for all those examples is that the parameter we want to predi
 ## Solution
 To solve this problem, first we will build an ML model. Then we will train the model on existing data, evaluate how good it is, and lastly we'll consume the model to predict taxi fares.
 
-![Build -> Train -> Evaluate -> Consume](https://github.com/dotnet/machinelearning-samples/raw/master/samples/getting-started/shared_content/modelpipeline.png)
+![Build -> Train -> Evaluate -> Consume](https://raw.githubusercontent.com/dotnet/machinelearning-samples/master/samples/csharp/getting-started/shared_content/modelpipeline.png)
 
 ### 1. Build model
 


### PR DESCRIPTION
Fix broken image in https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started/Regression_TaxiFarePrediction
![image](https://user-images.githubusercontent.com/20010676/46370699-5d270600-c697-11e8-98ff-daa4e9613cd7.png)
