### PR TITLE
#83 Moved Clustering_Iris F# sample to new dynamic API. 

### DIFF
--- a/samples/fsharp/getting-started/Clustering_Iris/Clustering_Iris.fsproj
+++ b/samples/fsharp/getting-started/Clustering_Iris/Clustering_Iris.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Program.fs" />
     <Folder Include="datasets\" />
     <None Include="..\..\..\..\datasets\iris-full.txt" Link="datasets\iris-full.txt" />
+    <None Include="README.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/fsharp/getting-started/Clustering_Iris/Program.fs
+++ b/samples/fsharp/getting-started/Clustering_Iris/Program.fs
@@ -3,114 +3,128 @@
 open System
 open System.IO
 
-open Microsoft.ML.Runtime.Api;
-open Microsoft.ML.Legacy;
-open Microsoft.ML.Legacy.Data;
-open Microsoft.ML.Legacy.Transforms;
-open Microsoft.ML.Legacy.Trainers;
+open Microsoft.ML.Runtime.Data
+open Microsoft.ML.Runtime.Api
+open Microsoft.ML.Runtime.KMeans
+
 
 let AppPath = Path.Combine(__SOURCE_DIRECTORY__, "../../../..")
 let DataPath = Path.Combine(AppPath, "datasets", "iris-full.txt")
-let ModelPath = Path.Combine(AppPath, "IrisClustersModel.zip")
+let modelPath = Path.Combine(AppPath, "IrisClustersModel.zip")
 
+
+
+/// Describes Iris flower. Used as an input to prediction function.
 [<CLIMutable>]
 type IrisData = {
-    [<Column("0")>] Label : float32
-    [<Column("1")>] SepalLength : float32
-    [<Column("2")>] SepalWidth: float32
-    [<Column("3")>] PetalLength : float32
-    [<Column("4")>] PetalWidth : float32
-} with static member Empty = {
-        Label = 0.0f
-        SepalLength = 0.0f
-        SepalWidth = 0.0f
-        PetalLength = 0.0f
-        PetalWidth = 0.0f
-    }
+    SepalLength : float32
+    SepalWidth: float32
+    PetalLength : float32
+    PetalWidth : float32
+} 
 
+/// Represents result of prediction - the cluster to which Iris flower has been classified.
 [<CLIMutable>]
-type ClusterPrediction = {
+type IrisPrediction = {
     [<ColumnName("PredictedLabel")>] SelectedClusterId : uint32
     [<ColumnName("Score")>] Distance : float32[]
 }
 
-//type IrisData() =
-    //[<Column("0")>]
-    //member val Label: float32 = 0.0f with get,set
 
-    //[<Column("1")>]
-    //member val SepalLength: float32 = 0.0f with get, set
 
-    //[<Column("2")>]
-    //member val SepalWidth: float32 = 0.0f with get, set
+module Pipeline =
+    open Microsoft.ML.Core.Data
 
-    //[<Column("3")>]
-    //member val PetalLength: float32 = 0.0f with get, set
+    let textTransform (inputColumn : string) outputColumn env =
+        TextTransform(env, inputColumn, outputColumn)
 
-    //[<Column("4")>]
-    //member val PetalWidth: float32 = 0.0f with get, set
+    let concatEstimator name source env =
+        ConcatEstimator(env,name, source)
 
-//type ClusterPrediction() =
-    //[<ColumnName("PredictedLabel")>]
-    //member val SelectedClusterId: uint32 = 0u with get, set
+    let append (estimator : IEstimator<'b>) (pipeline : IEstimator<ITransformer>)  = 
+        pipeline.Append estimator
+        
+    let fit (dataView : IDataView) (pipeline : EstimatorChain<'a>) =
+        pipeline.Fit dataView
 
-    //[<ColumnName("Score")>]
-    //member val Distance: float32[] = null with get, set
 
-let Train() =
-    // LearningPipeline holds all steps of the learning process: data, transforms, learners.
-    let pipeline = LearningPipeline()
-    // The TextLoader loads a dataset. The schema of the dataset is specified by passing a class containing
-    // all the column names and their types.
-    pipeline.Add(TextLoader(DataPath).CreateFrom<IrisData>(useHeader=true))
-    // ColumnConcatenator concatenates all columns into Features column
-    pipeline.Add(ColumnConcatenator("Features",
-                                    "SepalLength",
-                                    "SepalWidth",
-                                    "PetalLength",
-                                    "PetalWidth"))
-    // KMeansPlusPlusClusterer is an algorithm that will be used to build clusters. We set the number of clusters to 3.
-    pipeline.Add(KMeansPlusPlusClusterer(K = 3))
+let saveModelAsFile env (model : TransformerChain<'a>) =
+    use fs = new FileStream(modelPath, FileMode.Create, FileAccess.Write, FileShare.Write)
+    model.SaveTo(env, fs)
 
-    printfn "=============== Training model ==============="
-    let model = pipeline.Train<IrisData, ClusterPrediction>()
-    printfn "=============== End training ==============="
+    printfn "The model is saved to %s" modelPath
 
-    // Saving the model as a .zip file.
-    model.WriteAsync(ModelPath) |> Async.AwaitTask |> Async.RunSynchronously
 
-    printfn "The model is saved to %s" ModelPath
+let predictWithModelLoadedFromFile() =
 
-    model
+    let sampleIrisData = 
+        { 
+            SepalLength = 3.3f
+            SepalWidth = 1.6f
+            PetalLength = 0.2f
+            PetalWidth = 5.1f 
+        }
 
-module TestIrisData =
-    let Setosa1 =  { IrisData.Empty with SepalLength = 5.1f; SepalWidth = 3.3f; PetalLength = 1.6f; PetalWidth = 0.2f }
-    let Setosa2 = { IrisData.Empty with SepalLength = 0.2f; SepalWidth = 5.1f; PetalLength = 3.5f; PetalWidth = 1.4f}
-    let Virginica1 = { IrisData.Empty with SepalLength = 6.4f; SepalWidth = 3.1f; PetalLength = 5.5f; PetalWidth = 2.2f}
-    let Virginica2 = { IrisData.Empty with SepalLength = 2.5f; SepalWidth = 6.3f; PetalLength = 3.3f; PetalWidth = 6.0f}
-    let Versicolor1 = { IrisData.Empty with SepalLength = 6.4f; SepalWidth = 3.1f; PetalLength = 4.5f; PetalWidth = 1.5f}
-    let Versicolor2 = { IrisData.Empty with SepalLength = 7.0f; SepalWidth = 3.2f; PetalLength = 4.7f; PetalWidth = 1.4f}
+    // Test with Loaded Model from .zip file
 
-// STEP 1: Create a model
-let model = Train()
+    use env = new LocalEnvironment()
+    use stream = new FileStream(modelPath, FileMode.Open, FileAccess.Read, FileShare.Read)
+    let loadedModel = TransformerChain.LoadFrom(env, stream)
 
-// STEP 2: Make a prediction
-Console.WriteLine()
-let prediction1 = model.Predict(TestIrisData.Setosa1)
-let prediction2 = model.Predict(TestIrisData.Setosa2)
-printfn "Clusters assigned for setosa flowers:"
-printfn "                                        {%d}" prediction1.SelectedClusterId
-printfn "                                        {%d}" prediction2.SelectedClusterId
+    // Create prediction engine and make prediction.
 
-let prediction3 = model.Predict(TestIrisData.Virginica1)
-let prediction4 = model.Predict(TestIrisData.Virginica2)
-printfn "Clusters assigned for virginica flowers:"
-printfn "                                        {%d}" prediction3.SelectedClusterId
-printfn "                                        {%d}" prediction4.SelectedClusterId
+    let predictionFunc = loadedModel.MakePredictionFunction<IrisData, IrisPrediction> env
+    let prediction = predictionFunc.Predict sampleIrisData
 
-let prediction5 = model.Predict(TestIrisData.Versicolor1)
-let prediction6 = model.Predict(TestIrisData.Versicolor2)
-printfn "Clusters assigned for versicolor flowers:"
-printfn "                                        {%d}" prediction5.SelectedClusterId
-printfn "                                        {%d}" prediction6.SelectedClusterId
-Console.ReadLine() |> ignore
+    printfn ""
+    printfn "Clusters assigned for setosa flowers: %d" prediction.SelectedClusterId
+    printfn ""
+
+
+[<EntryPoint>]
+let main argv =
+    
+    //1. Create ML.NET context/environment
+    use env = new LocalEnvironment()
+
+    //2. Create DataReader with data schema mapped to file's columns
+    let reader = 
+        TextLoader(
+            env, 
+            TextLoader.Arguments(
+                Separator = "tab", 
+                HasHeader = true, 
+                Column = 
+                    [|
+                        TextLoader.Column("Label", Nullable DataKind.R4, 0)
+                        TextLoader.Column("SepalLength", Nullable DataKind.R4, 1)
+                        TextLoader.Column("SepalWidth", Nullable DataKind.R4, 2)
+                        TextLoader.Column("PetalLength", Nullable DataKind.R4, 3)
+                        TextLoader.Column("PetalWidth", Nullable DataKind.R4, 4)
+                    |]
+                )
+            )
+
+    //Load training data
+    let trainingDataView = MultiFileSource(DataPath) |> reader.Read
+    
+    // Create and train the model            
+    printfn "=============== Create and Train the Model ==============="
+
+    let model = 
+        env
+        //3.Create a flexible pipeline (composed by a chain of estimators) for creating/traing the model.
+        |> Pipeline.concatEstimator "Features" [| "SepalLength"; "SepalWidth"; "PetalLength"; "PetalWidth" |]
+        |> Pipeline.append (KMeansPlusPlusTrainer(env, "Features", clustersCount = 3))
+        //4. Create and train the model            
+        |> Pipeline.fit trainingDataView
+
+    printfn "=============== End of training ==============="
+    printfn ""
+
+    saveModelAsFile env model
+
+    predictWithModelLoadedFromFile()
+    
+    
+    0 // return an integer exit code

--- a/samples/fsharp/getting-started/Clustering_Iris/README.md
+++ b/samples/fsharp/getting-started/Clustering_Iris/README.md
@@ -2,15 +2,7 @@
 
 | ML.NET version | API type          | Status                        | App Type    | Data type | Scenario            | ML Task                   | Algorithms                  |
 |----------------|-------------------|-------------------------------|-------------|-----------|---------------------|---------------------------|-----------------------------|
-| v0.6           | LearningPipeline API | Needs update to  Dynamic API: [Contribute](/CONTRIBUTING.md) | Console app | .txt file | Clustering Iris flowers | Clustering | K-means++ |
-
-------------------------------------
-
-**Important**: This F# sample needs to be updated to the new dynamic API available since ML.NET 0.6. It currently uses the deprecated LearningPipeline API.
-
-Contribution from the community will be welcomed! 
-
-------------------------------------
+| v0.6           | Dynamic API | Up-to-date | Console app | .txt file | Clustering Iris flowers | Clustering | K-means++ |
 
 In this introductory sample, you'll see how to use [ML.NET](https://www.microsoft.com/net/learn/apps/machine-learning-and-ai/ml-dotnet) to divide iris flowers into different groups that correspond to different types of iris. In the world of machine learning, this task is known as **clustering**.
 
@@ -39,43 +31,58 @@ To solve this problem, first we will build and train an ML model. Then we will u
 ### 1. Build model
 
 Building a model includes: uploading data (`iris-full.txt` with `TextLoader`), transforming the data so it can be used effectively by an ML algorithm (with `ColumnConcatenator`), and choosing a learning algorithm (`KMeansPlusPlusClusterer`). All of those steps are stored in a `LearningPipeline`:
-
 ```fsharp
-// LearningPipeline holds all steps of the learning process: data, transforms, learners.
-let pipeline = LearningPipeline()
-// The TextLoader loads a dataset. The schema of the dataset is specified by passing a class containing
-// all the column names and their types.
-pipeline.Add(TextLoader(DataPath).CreateFrom<IrisData>(useHeader=true))
+	// LearningPipeline holds all steps of the learning process: data, transforms, learners.
+    
+	//1. Create ML.NET context/environment
+    use env = new LocalEnvironment()
 
-// ColumnConcatenator concatenates all columns into Features column
-pipeline.Add(ColumnConcatenator("Features",
-                "SepalLength",
-                "SepalWidth",
-                "PetalLength",
-                "PetalWidth"))
+    //2. Create DataReader with data schema mapped to file's columns
+    let reader = 
+        TextLoader(
+            env, 
+            TextLoader.Arguments(
+                Separator = "tab", 
+                HasHeader = true, 
+                Column = 
+                    [|
+                        TextLoader.Column("Label", Nullable DataKind.R4, 0)
+                        TextLoader.Column("SepalLength", Nullable DataKind.R4, 1)
+                        TextLoader.Column("SepalWidth", Nullable DataKind.R4, 2)
+                        TextLoader.Column("PetalLength", Nullable DataKind.R4, 3)
+                        TextLoader.Column("PetalWidth", Nullable DataKind.R4, 4)
+                    |]
+                )
+            )
 
-// KMeansPlusPlusClusterer is an algorithm that will be used to build clusters. We set the number of clusters to 3.
-pipeline.Add(KMeansPlusPlusClusterer(K = 3))
+    //Load training data
+    let trainingDataView = MultiFileSource(DataPath) |> reader.Read
 ```
-
 ### 2. Train model
-Training the model is a process of running the chosen algorithm on the given data. It is implemented in the `Train()` API. To perform training we just call the method and provide our data object  `IrisData` and  prediction object `ClusterPrediction`.
-
+Training the model is a process of running the chosen algorithm on the given data. It is implemented in the `Fit()` method from the Estimator object. To perform training we just call the method and provide our data object  `IrisData` and  prediction object `ClusterPrediction`.
 ```fsharp
-let model = pipeline.Train<IrisData, ClusterPrediction>()
-```
+    let model = 
+        env
+        |> Pipeline.concatEstimator "Features" [| "SepalLength"; "SepalWidth"; "PetalLength"; "PetalWidth" |]
+        |> Pipeline.append (KMeansPlusPlusTrainer(env, "Features", clustersCount = 3))
+        |> Pipeline.fit trainingDataView
 
+```
 ### 3. Consume model
 After the model is build and trained, we can use the `Predict()` API to predict the cluster for an iris flower and calculate the distance from given flower parameters to each cluster (each centroid of a cluster).
 
 ```fsharp
-let prediction1 = model.Predict(TestIrisData.Setosa1)
+    let sampleIrisData = 
+        { 
+            SepalLength = 3.3f
+            SepalWidth = 1.6f
+            PetalLength = 0.2f
+            PetalWidth = 5.1f 
+        }
+
+    let predictionFunc = loadedModel.MakePredictionFunction<IrisData, IrisPrediction> env
+    let prediction = predictionFunc.Predict sampleIrisData
+
+    printfn "Clusters assigned for setosa flowers: %d" prediction.SelectedClusterId
 ```
-
-Where `TestIrisData.Setosa1` stores the information about a setosa iris flower.
-
-```fsharp
-module TestIrisData = 
-    let Setosa1 = IrisData(SepalLength = 5.1, SepalWidth = 3.3, PetalLength = 1.6, PetalWidth = 0.2)
-    ...
 ```

--- a/samples/fsharp/getting-started/Clustering_Iris/README.md
+++ b/samples/fsharp/getting-started/Clustering_Iris/README.md
@@ -30,7 +30,7 @@ To solve this problem, first we will build and train an ML model. Then we will u
 
 ### 1. Build model
 
-Building a model includes: uploading data (`iris-full.txt` with `TextLoader`), transforming the data so it can be used effectively by an ML algorithm (with `ColumnConcatenator`), and choosing a learning algorithm (`KMeansPlusPlusClusterer`). All of those steps are stored in a `LearningPipeline`:
+Building a model includes: uploading data (`iris-full.txt` with `TextLoader`), transforming the data so it can be used effectively by an ML algorithm (with `ConcatEstimator`), and choosing a learning algorithm (`KMeansPlusPlusTrainer`). All of those steps are stored in a `EstimatorChain`:
 ```fsharp
 	// LearningPipeline holds all steps of the learning process: data, transforms, learners.
     
@@ -59,7 +59,7 @@ Building a model includes: uploading data (`iris-full.txt` with `TextLoader`), t
     let trainingDataView = MultiFileSource(DataPath) |> reader.Read
 ```
 ### 2. Train model
-Training the model is a process of running the chosen algorithm on the given data. It is implemented in the `Fit()` method from the Estimator object. To perform training we just call the method and provide our data object  `IrisData` and  prediction object `ClusterPrediction`.
+Training the model is a process of running the chosen algorithm on the given data. It is implemented in the `Fit()` method from the Estimator object. To perform training we just call the method and provide our data.
 ```fsharp
     let model = 
         env


### PR DESCRIPTION
Migration done by following C# sample.
Continued with Pipeline module introduced with BinaryClassification_SentimentAnalysis sample, which is supposed to make some operations on pipeline more F# friendly. This allows to pipe operations for creating pipeline and training model (idea is similar to Seq/List/Array modules which allow to pipe chain methods):
```fsharp
    let model = 
        env
        |> Pipeline.concatEstimator "Features" [| "SepalLength"; "SepalWidth"; "PetalLength"; "PetalWidth" |]
        |> Pipeline.append (KMeansPlusPlusTrainer(env, "Features", clustersCount = 3))
        |> Pipeline.fit trainingDataView
```

For now I copied file from BinaryClassification_SentimentAnalysis sample and added concatEstimator function, but I am thinking about moving it outside and share between projects.

Applied code style suggestions from #85.