### PR TITLE
DS Review: Improved three samples

### DIFF
--- a/samples/csharp/getting-started/BinaryClasification_Titanic/BinaryClasification_TitanicSurvivalPrediction/Program.cs
+++ b/samples/csharp/getting-started/BinaryClasification_Titanic/BinaryClasification_TitanicSurvivalPrediction/Program.cs
@@ -43,13 +43,19 @@ namespace BinaryClasification_TitanicSurvivalPrediction
             // all the column names and their types.
             pipeline.Add(new TextLoader(TrainDataPath).CreateFrom<TitanicData>(useHeader: true, separator: ','));
 
-            // Transform any text feature to numeric values
+            // Transform low-dimensional categorical columns to one-hot indicators
             pipeline.Add(new CategoricalOneHotVectorizer(
                 "Sex",
-                "Ticket",
-                "Fare",
                 "Cabin",
+                "Pclass",
+                "SibSp",
+                "Parch",
                 "Embarked"));
+
+            // Transform high-dimensional categorical columns to one-hot hash indicators
+            pipeline.Add(new CategoricalHashOneHotVectorizer(
+                "Ticket",
+                "Cabin") { HashBits = 2 });
 
             // Put all features into a vector
             pipeline.Add(new ColumnConcatenator(
@@ -66,7 +72,7 @@ namespace BinaryClasification_TitanicSurvivalPrediction
 
             // FastTreeBinaryClassifier is an algorithm that will be used to train the model.
             // It has three hyperparameters for tuning decision tree performance. 
-            pipeline.Add(new FastTreeBinaryClassifier() {NumLeaves = 5, NumTrees = 5, MinDocumentsInLeafs = 2});
+            pipeline.Add(new FastTreeBinaryClassifier());// {NumLeaves = 5, NumTrees = 5, MinDocumentsInLeafs = 2});
 
             Console.WriteLine("=============== Training model ===============");
             // The pipeline is trained on the dataset that has been loaded and transformed.

--- a/samples/csharp/getting-started/BinaryClasification_Titanic/BinaryClasification_TitanicSurvivalPrediction/TestTitanicData.cs
+++ b/samples/csharp/getting-started/BinaryClasification_Titanic/BinaryClasification_TitanicSurvivalPrediction/TestTitanicData.cs
@@ -13,7 +13,7 @@ namespace BinaryClasification_TitanicSurvivalPrediction
             SibSp = 0,
             Parch = 1,
             Ticket = "230433",
-            Fare = "26",
+            Fare = 26,
             Cabin = "",
             Embarked = "S"
         };

--- a/samples/csharp/getting-started/BinaryClasification_Titanic/BinaryClasification_TitanicSurvivalPrediction/TitanicData.cs
+++ b/samples/csharp/getting-started/BinaryClasification_Titanic/BinaryClasification_TitanicSurvivalPrediction/TitanicData.cs
@@ -32,7 +32,7 @@ namespace BinaryClasification_TitanicSurvivalPrediction
         public string Ticket;
 
         [Column("9")]
-        public string Fare;
+        public float Fare;
 
         [Column("10")]
         public string Cabin;

--- a/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Train/ModelBuilder/ModelBuilder.cs
+++ b/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Train/ModelBuilder/ModelBuilder.cs
@@ -34,12 +34,12 @@ namespace CustomerSegmentation.Model
             return reader;
         }
 
-        public TransformerChain<ClusteringPredictionTransformer<KMeansPredictor>> BuildAndTrain(string pivotLocation, int kClusters = 3, int rank = 2, int seed = 42)
+        public TransformerChain<ClusteringPredictionTransformer<KMeansPredictor>> BuildAndTrain(string pivotLocation, int kClusters = 3, int rank = 2)
         {
             ConsoleWriteHeader("Build and Train using Static API");
             Console.Out.WriteLine($"Input file: {pivotLocation}");
 
-            var pipeline = new PcaEstimator(env, "Features", "PCAFeatures", rank: rank, advancedSettings: (p) => p.Seed = seed)
+            var pipeline = new PcaEstimator(env, "Features", "PCAFeatures", rank: rank)
                 .Append(new CategoricalEstimator(env, new[] { new CategoricalEstimator.ColumnInfo("LastName", "LastNameKey", CategoricalTransform.OutputKind.Ind) }))
                 .Append(new KMeansPlusPlusTrainer(env, "Features", clustersCount: kClusters));
 

--- a/samples/csharp/getting-started/Regression_TaxiFarePrediction/Program.cs
+++ b/samples/csharp/getting-started/Regression_TaxiFarePrediction/Program.cs
@@ -75,6 +75,9 @@ namespace Regression_TaxiFarePrediction
                                     .Append(new CategoricalEstimator(mlcontext, "VendorId"))
                                     .Append(new CategoricalEstimator(mlcontext, "RateCode"))
                                     .Append(new CategoricalEstimator(mlcontext, "PaymentType"))
+                                    .Append(new Normalizer(mlcontext, "PassengerCount", Normalizer.NormalizerMode.MeanVariance))
+                                    .Append(new Normalizer(mlcontext, "TripTime", Normalizer.NormalizerMode.MeanVariance))
+                                    .Append(new Normalizer(mlcontext, "TripDistance", Normalizer.NormalizerMode.MeanVariance))
                                     .Append(new ConcatEstimator(mlcontext, "Features", "VendorId", "RateCode", "PassengerCount", "TripTime", "TripDistance", "PaymentType"));
 
             // We apply our selected Trainer (SDCA Regression algorithm)

--- a/samples/csharp/getting-started/Regression_TaxiFarePrediction/Program.cs
+++ b/samples/csharp/getting-started/Regression_TaxiFarePrediction/Program.cs
@@ -111,11 +111,10 @@ namespace Regression_TaxiFarePrediction
             Console.WriteLine($"*************************************************");
             Console.WriteLine($"*       Metrics for {algorithmName}          ");
             Console.WriteLine($"*------------------------------------------------");
-            Console.WriteLine($"*       LossFn: {metrics.LossFn:0.##}");
             Console.WriteLine($"*       R2 Score: {metrics.RSquared:0.##}");
+            Console.WriteLine($"*       RMS loss: {metrics.Rms:#.##}");
             Console.WriteLine($"*       Absolute loss: {metrics.L1:#.##}");
             Console.WriteLine($"*       Squared loss: {metrics.L2:#.##}");
-            Console.WriteLine($"*       RMS loss: {metrics.Rms:#.##}");
             Console.WriteLine($"*************************************************");
 
             return metrics;


### PR DESCRIPTION
Related to #81.
Improved the following samples:

## Clustering_CustomerSegmentation
* Removed PCA seed

## Regression_TaxiFarePrediction
* Removed LossFn
* Improved metrics:

Before:
- R2 Score: 0.58
- RMS loss: 7.03
- Absolute loss: 2.02

After:
- R2 Score: 0.7
- RMS loss: 5.97
- Absolute loss: .99

## BinaryClasification_Titanic sample
Improved features and learner:
- Default params for fasttree
- Fare -> numeric
- Improved transformation of categorical features 

Metrics before:
- Accuracy: 80.85 %
- Auc: 82.27 %
- F1Score: 67.47 %

Metrics after:
- Accuracy: 85.11 %
- Auc: 87.47 %
- F1Score: 79.21 %
