### PR TITLE
#167: reference ML.NET v0.7.0 in F# project to fix build issues.

### DIFF
--- a/samples/fsharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/GitHubLabeler.fsproj
+++ b/samples/fsharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/GitHubLabeler.fsproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML" Version="0.7.0" />
     <PackageReference Include="Octokit" Version="0.29.0" />
   </ItemGroup>
 

--- a/samples/fsharp/getting-started/BinaryClassification_SentimentAnalysis/SentimentAnalysis/SentimentAnalysisConsoleApp/SentimentAnalysisConsoleApp.fsproj
+++ b/samples/fsharp/getting-started/BinaryClassification_SentimentAnalysis/SentimentAnalysis/SentimentAnalysisConsoleApp/SentimentAnalysisConsoleApp.fsproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/fsharp/getting-started/Clustering_Iris/IrisClustering/IrisClusteringConsoleApp/Clustering_Iris.fsproj
+++ b/samples/fsharp/getting-started/Clustering_Iris/IrisClustering/IrisClusteringConsoleApp/Clustering_Iris.fsproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/fsharp/getting-started/MulticlassClassification_Iris/IrisClassification/IrisClassificationConsoleApp/MulticlassClassification_Iris.fsproj
+++ b/samples/fsharp/getting-started/MulticlassClassification_Iris/IrisClassification/IrisClassificationConsoleApp/MulticlassClassification_Iris.fsproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/fsharp/getting-started/Regression_BikeSharingDemand/BikeSharingDemand/BikeSharingDemandConsoleApp/BikeSharingDemand.fsproj
+++ b/samples/fsharp/getting-started/Regression_BikeSharingDemand/BikeSharingDemand/BikeSharingDemandConsoleApp/BikeSharingDemand.fsproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup />

--- a/samples/fsharp/getting-started/Regression_TaxiFarePrediction/TaxiFarePrediction/TaxiFarePredictionConsoleApp/Regression_TaxiFarePrediction.csproj.fsproj
+++ b/samples/fsharp/getting-started/Regression_TaxiFarePrediction/TaxiFarePrediction/TaxiFarePredictionConsoleApp/Regression_TaxiFarePrediction.csproj.fsproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML" Version="0.7.0" />
     <PackageReference Include="PLplot" Version="5.13.7" />
   </ItemGroup>
 


### PR DESCRIPTION
The problem was because variable `$(MicrosoftMLVersion)`  has been updated to point to ML.NET v0.8.0 and there are breaking changes between v0.7 and v0.8. I have referenced v0.7 for now while we updating samples to v0.8