### PR TITLE
Update PeekViewToConsole method to to use Preview()

### DIFF
--- a/samples/csharp/common/ConsoleHelper.cs
+++ b/samples/csharp/common/ConsoleHelper.cs
@@ -166,10 +166,9 @@ namespace Common
             Console.WriteLine($"*************************************************");
         }
 
-        public static void PeekDataViewInConsole<TObservation>(MLContext mlContext, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
-            where TObservation : class, new()
+        public static void PeekDataViewInConsole(MLContext mlContext, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
         {
-            string msg = string.Format("Peek data in DataView: Showing {0} rows with the columns specified by TObservation class", numberOfRows.ToString());
+            string msg = string.Format("Peek data in DataView: Showing {0} rows with the columns", numberOfRows.ToString());
             ConsoleWriteHeader(msg);
 
             //https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetCookBook.md#how-do-i-look-at-the-intermediate-data

--- a/samples/csharp/common/ConsoleHelper.cs
+++ b/samples/csharp/common/ConsoleHelper.cs
@@ -191,54 +191,7 @@ namespace Common
                 Console.WriteLine(lineToPrint + "\n");
             }
         }
-
-        //public static List<TObservation> PeekDataViewInConsole<TObservation>(MLContext mlContext, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
-        //    where TObservation : class, new()
-        //{
-        //    string msg = string.Format("Peek data in DataView: Showing {0} rows with the columns specified by TObservation class", numberOfRows.ToString());
-        //    ConsoleWriteHeader(msg);
-
-        //    //https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetCookBook.md#how-do-i-look-at-the-intermediate-data
-        //    var transformer = pipeline.Fit(dataView);
-        //    var transformedData = transformer.Transform(dataView);
-
-        //    // 'transformedData' is a 'promise' of data, lazy-loading. Let's actually read it.
-        //    // Convert to an enumerable of user-defined type.
-
-        //    //Preview<TSource>(this IDataReader<TSource> reader, TSource source, int maxRows = 100);
-
-        //    var someRows = mlContext.CreateEnumerable<TObservation>(transformedData, reuseRowObject: false)
-        //                                   // Take the specified number of rows
-        //                                   .Take(numberOfRows)
-        //                                   // Convert to List
-        //                                   .ToList();
-        //    // v0.9
-        //    //
-        //    //var someRows = transformedData.AsEnumerable<TObservation>(mlContext, reuseRowObject: false)
-        //    //                               // Take the specified number of rows
-        //    //                               .Take(numberOfRows)
-        //    //                               // Convert to List
-        //    //                               .ToList();
-
-        //    someRows.ForEach(row =>
-        //                        {
-        //                            string lineToPrint = "Row--> ";
-
-        //                            var fieldsInRow = row.GetType().GetFields(BindingFlags.Instance |
-        //                                                                      BindingFlags.Static |
-        //                                                                      BindingFlags.NonPublic |
-
-        //                                                                      BindingFlags.Public);
-        //                            foreach (FieldInfo field in fieldsInRow)
-        //                            {
-        //                                lineToPrint += $"| {field.Name}: {field.GetValue(row)}";
-        //                            }
-        //                            Console.WriteLine(lineToPrint);
-        //                        });
-
-        //    return someRows;
-        //}
-
+      
         public static List<float[]> PeekVectorColumnDataInConsole(MLContext mlContext, string columnName, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
         {
             string msg = string.Format("Peek data in DataView: : Show {0} rows with just the '{1}' column", numberOfRows, columnName );

--- a/samples/csharp/common/ConsoleHelper.cs
+++ b/samples/csharp/common/ConsoleHelper.cs
@@ -166,7 +166,7 @@ namespace Common
             Console.WriteLine($"*************************************************");
         }
 
-        public static List<TObservation> PeekDataViewInConsole<TObservation>(MLContext mlContext, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
+        public static void PeekDataViewInConsole<TObservation>(MLContext mlContext, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
             where TObservation : class, new()
         {
             string msg = string.Format("Peek data in DataView: Showing {0} rows with the columns specified by TObservation class", numberOfRows.ToString());
@@ -179,38 +179,66 @@ namespace Common
             // 'transformedData' is a 'promise' of data, lazy-loading. Let's actually read it.
             // Convert to an enumerable of user-defined type.
 
-            //Preview<TSource>(this IDataReader<TSource> reader, TSource source, int maxRows = 100);
+            var preViewTransformedData = transformedData.Preview(maxRows: numberOfRows);
 
-            var someRows = mlContext.CreateEnumerable<TObservation>(transformedData, reuseRowObject: false)
-                                           // Take the specified number of rows
-                                           .Take(numberOfRows)
-                                           // Convert to List
-                                           .ToList();
-            // v0.9
-            //
-            //var someRows = transformedData.AsEnumerable<TObservation>(mlContext, reuseRowObject: false)
-            //                               // Take the specified number of rows
-            //                               .Take(numberOfRows)
-            //                               // Convert to List
-            //                               .ToList();
-
-            someRows.ForEach(row =>
-                                {
-                                    string lineToPrint = "Row--> ";
-
-                                    var fieldsInRow = row.GetType().GetFields(BindingFlags.Instance |
-                                                                              BindingFlags.Static |
-                                                                              BindingFlags.NonPublic |
-                                                                              BindingFlags.Public);
-                                    foreach (FieldInfo field in fieldsInRow)
-                                    {
-                                        lineToPrint += $"| {field.Name}: {field.GetValue(row)}";
-                                    }
-                                    Console.WriteLine(lineToPrint);
-                                });
-
-            return someRows;
+            foreach (var row in preViewTransformedData.RowView)
+            {
+                var ColumnCollection = row.Values;
+                string lineToPrint = "Row--> ";
+                foreach (KeyValuePair<string, object> column in ColumnCollection)
+                {
+                    lineToPrint += $"| {column.Key}:{column.Value}";
+                }
+                Console.WriteLine(lineToPrint + "\n");
+            }
         }
+
+        //public static List<TObservation> PeekDataViewInConsole<TObservation>(MLContext mlContext, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
+        //    where TObservation : class, new()
+        //{
+        //    string msg = string.Format("Peek data in DataView: Showing {0} rows with the columns specified by TObservation class", numberOfRows.ToString());
+        //    ConsoleWriteHeader(msg);
+
+        //    //https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetCookBook.md#how-do-i-look-at-the-intermediate-data
+        //    var transformer = pipeline.Fit(dataView);
+        //    var transformedData = transformer.Transform(dataView);
+
+        //    // 'transformedData' is a 'promise' of data, lazy-loading. Let's actually read it.
+        //    // Convert to an enumerable of user-defined type.
+
+        //    //Preview<TSource>(this IDataReader<TSource> reader, TSource source, int maxRows = 100);
+
+        //    var someRows = mlContext.CreateEnumerable<TObservation>(transformedData, reuseRowObject: false)
+        //                                   // Take the specified number of rows
+        //                                   .Take(numberOfRows)
+        //                                   // Convert to List
+        //                                   .ToList();
+        //    // v0.9
+        //    //
+        //    //var someRows = transformedData.AsEnumerable<TObservation>(mlContext, reuseRowObject: false)
+        //    //                               // Take the specified number of rows
+        //    //                               .Take(numberOfRows)
+        //    //                               // Convert to List
+        //    //                               .ToList();
+
+        //    someRows.ForEach(row =>
+        //                        {
+        //                            string lineToPrint = "Row--> ";
+
+        //                            var fieldsInRow = row.GetType().GetFields(BindingFlags.Instance |
+        //                                                                      BindingFlags.Static |
+        //                                                                      BindingFlags.NonPublic |
+
+        //                                                                      BindingFlags.Public);
+        //                            foreach (FieldInfo field in fieldsInRow)
+        //                            {
+        //                                lineToPrint += $"| {field.Name}: {field.GetValue(row)}";
+        //                            }
+        //                            Console.WriteLine(lineToPrint);
+        //                        });
+
+        //    return someRows;
+        //}
 
         public static List<float[]> PeekVectorColumnDataInConsole(MLContext mlContext, string columnName, IDataView dataView, IEstimator<ITransformer> pipeline, int numberOfRows = 4)
         {

--- a/samples/csharp/common/ConsoleHelper.cs
+++ b/samples/csharp/common/ConsoleHelper.cs
@@ -175,8 +175,8 @@ namespace Common
             var transformer = pipeline.Fit(dataView);
             var transformedData = transformer.Transform(dataView);
 
-            // 'transformedData' is a 'promise' of data, lazy-loading. Let's actually read it.
-            // Convert to an enumerable of user-defined type.
+            // 'transformedData' is a 'promise' of data, lazy-loading. call Preview  
+            //and iterate through the returned collection from preview.
 
             var preViewTransformedData = transformedData.Preview(maxRows: numberOfRows);
 

--- a/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
+++ b/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
@@ -65,7 +65,7 @@ namespace GitHubLabeler
                             .AppendCacheCheckpoint(mlContext);  //In this sample, only when using OVA (Not SDCA) the cache improves the training time, since OVA works multiple times/iterations over the same data
 
             // (OPTIONAL) Peek data (such as 2 records) in training DataView after applying the ProcessPipeline's transformations into "Features" 
-            Common.ConsoleHelper.PeekDataViewInConsole<GitHubIssue>(mlContext, trainingDataView, dataProcessPipeline, 2);
+            Common.ConsoleHelper.PeekDataViewInConsole(mlContext, trainingDataView, dataProcessPipeline, 2);
             //Common.ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, "Features", trainingDataView, dataProcessPipeline, 2);
 
             // STEP 3: Create the selected training algorithm/trainer

--- a/samples/csharp/getting-started/BinaryClassification_SentimentAnalysis/SentimentAnalysis/SentimentAnalysisConsoleApp/Program.cs
+++ b/samples/csharp/getting-started/BinaryClassification_SentimentAnalysis/SentimentAnalysis/SentimentAnalysisConsoleApp/Program.cs
@@ -49,7 +49,7 @@ namespace SentimentAnalysisConsoleApp
             var dataProcessPipeline = mlContext.Transforms.Text.FeaturizeText(outputColumnName: DefaultColumnNames.Features, inputColumnName:nameof(SentimentIssue.Text));
 
             // (OPTIONAL) Peek data (such as 2 records) in training DataView after applying the ProcessPipeline's transformations into "Features" 
-            ConsoleHelper.PeekDataViewInConsole<SentimentIssue>(mlContext, trainingDataView, dataProcessPipeline, 2);
+            ConsoleHelper.PeekDataViewInConsole(mlContext, trainingDataView, dataProcessPipeline, 2);
             ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, DefaultColumnNames.Features, trainingDataView, dataProcessPipeline, 1);
 
             // STEP 3: Set the training algorithm, then create and config the modelBuilder                            

--- a/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Train/Program.cs
+++ b/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Train/Program.cs
@@ -52,7 +52,7 @@ namespace CustomerSegmentation
                                                 ));
 
                 // (Optional) Peek data in training DataView after applying the ProcessPipeline's transformations  
-                Common.ConsoleHelper.PeekDataViewInConsole<PivotObservation>(mlContext, pivotDataView, dataProcessPipeline, 10);
+                Common.ConsoleHelper.PeekDataViewInConsole(mlContext, pivotDataView, dataProcessPipeline, 10);
                 Common.ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, "Features", pivotDataView, dataProcessPipeline, 10);
 
                 //STEP 3: Create the training pipeline                

--- a/samples/csharp/getting-started/Clustering_Iris/IrisClustering/IrisClusteringConsoleApp/Program.cs
+++ b/samples/csharp/getting-started/Clustering_Iris/IrisClustering/IrisClusteringConsoleApp/Program.cs
@@ -45,7 +45,7 @@ namespace Clustering_Iris
             var dataProcessPipeline = mlContext.Transforms.Concatenate(DefaultColumnNames.Features, nameof(IrisData.SepalLength), nameof(IrisData.SepalWidth), nameof(IrisData.PetalLength), nameof(IrisData.PetalWidth));
 
             // (Optional) Peek data in training DataView after applying the ProcessPipeline's transformations  
-            Common.ConsoleHelper.PeekDataViewInConsole<IrisData>(mlContext, trainingDataView, dataProcessPipeline, 10);
+            Common.ConsoleHelper.PeekDataViewInConsole(mlContext, trainingDataView, dataProcessPipeline, 10);
             Common.ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, DefaultColumnNames.Features, trainingDataView, dataProcessPipeline, 10);
 
             // STEP 3: Create and train the model     

--- a/samples/csharp/getting-started/MulticlassClassification_HeartDisease/HeartDiseaseConsoleApp/Program.cs
+++ b/samples/csharp/getting-started/MulticlassClassification_HeartDisease/HeartDiseaseConsoleApp/Program.cs
@@ -43,7 +43,7 @@ namespace MulticlassClassification_HeartDisease
                                         .AppendCacheCheckpoint(mlContext);
 
             // (OPTIONAL) Peek data (such as 5 records) in training DataView after applying the ProcessPipeline's transformations into "Features" 
-            ConsoleHelper.PeekDataViewInConsole<HeartData>(mlContext, trainingDataView, dataProcessPipeline, 5);
+            ConsoleHelper.PeekDataViewInConsole(mlContext, trainingDataView, dataProcessPipeline, 5);
             ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, DefaultColumnNames.Features, trainingDataView, dataProcessPipeline, 5);
 
             var trainer = mlContext.MulticlassClassification.Trainers.StochasticDualCoordinateAscent(labelColumn: DefaultColumnNames.Label, featureColumn: DefaultColumnNames.Features);

--- a/samples/csharp/getting-started/Regression_BikeSharingDemand/BikeSharingDemand/BikeSharingDemandConsoleApp/Program.cs
+++ b/samples/csharp/getting-started/Regression_BikeSharingDemand/BikeSharingDemand/BikeSharingDemandConsoleApp/Program.cs
@@ -39,7 +39,7 @@ namespace BikeSharingDemand
                                          .AppendCacheCheckpoint(mlContext);
 
             // (Optional) Peek data in training DataView after applying the ProcessPipeline's transformations  
-            Common.ConsoleHelper.PeekDataViewInConsole<DemandObservation>(mlContext, trainingDataView, dataProcessPipeline, 10);
+            Common.ConsoleHelper.PeekDataViewInConsole(mlContext, trainingDataView, dataProcessPipeline, 10);
             Common.ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, DefaultColumnNames.Features, trainingDataView, dataProcessPipeline, 10);
 
             // Definition of regression trainers/algorithms to use

--- a/samples/csharp/getting-started/Regression_TaxiFarePrediction/TaxiFarePrediction/TaxiFarePredictionConsoleApp/Program.cs
+++ b/samples/csharp/getting-started/Regression_TaxiFarePrediction/TaxiFarePrediction/TaxiFarePredictionConsoleApp/Program.cs
@@ -73,7 +73,7 @@ namespace Regression_TaxiFarePrediction
                             , nameof(TaxiTrip.TripTime), nameof(TaxiTrip.TripDistance)));
 
             // (OPTIONAL) Peek data (such as 5 records) in training DataView after applying the ProcessPipeline's transformations into "Features" 
-            ConsoleHelper.PeekDataViewInConsole<TaxiTrip>(mlContext, trainingDataView, dataProcessPipeline, 5);
+            ConsoleHelper.PeekDataViewInConsole(mlContext, trainingDataView, dataProcessPipeline, 5);
             ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, DefaultColumnNames.Features, trainingDataView, dataProcessPipeline, 5);
 
             // STEP 3: Set the training algorithm, then create and config the modelBuilder - Selected Trainer (SDCA Regression algorithm)                            


### PR DESCRIPTION
Updated consolehelper.PeekViewToConsole() method to use preview().

List of samples which have ConsoleHelper.PeekViewToConsol():
1. BikeSharingDemand
2. Customer Segmentation
3. Git Hub Labeler
4. IRIS Clustering
5. TaxiFare Prediction
6. Heart Disease
7. Sentiment Analysis

