### PR TITLE
Turn off supportSparse in GitHubLabeler sample

### DIFF
--- a/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
+++ b/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
@@ -54,7 +54,7 @@ namespace GitHubLabeler
             var mlContext = new MLContext(seed: 0);
 
             // STEP 1: Common data loading configuration
-            var trainingDataView = mlContext.Data.ReadFromTextFile<GitHubIssue>(DataSetLocation, hasHeader: true, separatorChar:'\t');
+            var trainingDataView = mlContext.Data.ReadFromTextFile<GitHubIssue>(DataSetLocation, hasHeader: true, separatorChar:'\t', supportSparse: false);
              
             // STEP 2: Common data process configuration with pipeline data transformations
             var dataProcessPipeline = mlContext.Transforms.Conversion.MapValueToKey(outputColumnName: DefaultColumnNames.Label,inputColumnName:nameof(GitHubIssue.Area))


### PR DESCRIPTION
The input isn't sparse, but the ReadFromTextFile is using the default of
supportSparse=true, which is causing the loader to try and fail to parse
every row as if it were sparse (you can see this if you hook up an
mlcontext.Log handler and print out every message containing "Format").

Related to https://github.com/dotnet/machinelearning/issues/2576
cc: @CESARDELATORRE, @eerhardt 