### PR TITLE
Upgrade :Classify github issues into the best 3 labels instead of one label

### DIFF
--- a/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/DataStructures/FullPrediction.cs
+++ b/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/DataStructures/FullPrediction.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GitHubLabeler.DataStructures
+{
+    public class FullPrediction
+    {
+        public string PredictedLabel;
+        public float Score;
+        public int OriginalSchemaIndex;
+
+        public FullPrediction(string predictedLabel, float score, int originalSchemaIndex)
+        {
+            PredictedLabel = predictedLabel;
+            Score = score;
+            OriginalSchemaIndex = originalSchemaIndex;
+        }
+    }
+}

--- a/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/DataStructures/GitHubIssuePrediction.cs
+++ b/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/DataStructures/GitHubIssuePrediction.cs
@@ -9,5 +9,7 @@ namespace GitHubLabeler.DataStructures
     {
         [ColumnName("PredictedLabel")]
         public string Area;
+
+        public float[] Score;
     }
 }

--- a/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Labeler.cs
+++ b/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Labeler.cs
@@ -8,6 +8,7 @@ using Octokit;
 using System.IO;
 using GitHubLabeler.DataStructures;
 using Common;
+using Microsoft.ML.Data;
 
 namespace GitHubLabeler
 {
@@ -22,6 +23,8 @@ namespace GitHubLabeler
 
         private readonly PredictionEngine<GitHubIssue, GitHubIssuePrediction> _predEngine;
         private readonly ITransformer _trainedModel;
+
+        private FullPrediction[] _fullPredictions;
 
         public Labeler(string modelPath, string repoOwner = "", string repoName = "", string accessToken = "")
         {
@@ -54,12 +57,81 @@ namespace GitHubLabeler
 
         public void TestPredictionForSingleIssue()
         {
-            GitHubIssue singleIssue = new GitHubIssue() { ID = "Any-ID", Title = "Entity Framework crashes", Description = "When connecting to the database, EF is crashing" };
+            GitHubIssue singleIssue = new GitHubIssue() {
+                ID = "Any-ID",
+                Title = "Crash in SqlConnection when using TransactionScope",
+                Description = "I'm using SqlClient in netcoreapp2.0. Sqlclient.Close() crashes in Linux but works on Windows"
+            };
 
-            //Predict label for single hard-coded issue
-            //Score
+            //Predict labels and scores for single hard-coded issue
             var prediction = _predEngine.Predict(singleIssue);
+
+            _fullPredictions = GetBestThreePredictions(prediction);
+
+            Console.WriteLine("1st Label: " + _fullPredictions[0].PredictedLabel + " with score: " + _fullPredictions[0].Score);
+            Console.WriteLine("2nd Label: " + _fullPredictions[1].PredictedLabel + " with score: " + _fullPredictions[1].Score);
+            Console.WriteLine("3rd Label: " + _fullPredictions[2].PredictedLabel + " with score: " + _fullPredictions[2].Score);
+
             Console.WriteLine($"=============== Single Prediction - Result: {prediction.Area} ===============");
+        }
+
+        private FullPrediction[] GetBestThreePredictions(GitHubIssuePrediction prediction)
+        {
+            float[] scores = prediction.Score;
+            int size = scores.Length;
+            int index0, index1, index2 = 0;
+
+            VBuffer<ReadOnlyMemory<char>> slotNames = default;
+            _predEngine.OutputSchema[nameof(GitHubIssuePrediction.Score)].GetSlotNames(ref slotNames);
+
+            GetIndexesOfTopThreeScores(scores, size, out index0, out index1, out index2);
+
+            _fullPredictions = new FullPrediction[]
+                {
+                    new FullPrediction(slotNames.GetItemOrDefault(index0).ToString(),scores[index0],index0),
+                    new FullPrediction(slotNames.GetItemOrDefault(index1).ToString(),scores[index1],index1),
+                    new FullPrediction(slotNames.GetItemOrDefault(index2).ToString(),scores[index2],index2)
+                };
+
+            return _fullPredictions;
+        }
+
+        private void GetIndexesOfTopThreeScores(float[] scores, int n, out int index0, out int index1, out int index2)
+        {
+            int i;
+            float first, second, third;
+            index0 = index1 = index2 = 0;
+            if (n < 3)
+            {
+                Console.WriteLine("Invalid Input");
+                return;
+            }
+            third = first = second = 000;
+            for (i = 0; i < n; i++)
+            {
+                // If current element is  
+                // smaller than first 
+                if (scores[i] > first)
+                {
+                    third = second;
+                    second = first;
+                    first = scores[i];
+                }
+                // If arr[i] is in between first 
+                // and second then update second 
+                else if (scores[i] > second)
+                {
+                    third = second;
+                    second = scores[i];
+                }
+
+                else if (scores[i] > third)
+                    third = scores[i];
+            }
+            var scoresList = scores.ToList();
+            index0 = scoresList.IndexOf(first);
+            index1 = scoresList.IndexOf(second);
+            index2 = scoresList.IndexOf(third);
         }
 
         // Label all issues that are not labeled yet
@@ -68,8 +140,8 @@ namespace GitHubLabeler
             var newIssues = await GetNewIssues();
             foreach (var issue in newIssues.Where(issue => !issue.Labels.Any()))
             {
-                var label = PredictLabel(issue);
-                ApplyLabel(issue, label);
+                var label = PredictLabels(issue);
+                ApplyLabels(issue, label);
             }
         }
 
@@ -89,7 +161,7 @@ namespace GitHubLabeler
                             .ToList();
         }
 
-        private string PredictLabel(Octokit.Issue issue)
+        private FullPrediction[] PredictLabels(Octokit.Issue issue)
         {
             var corefxIssue = new GitHubIssue
             {
@@ -98,26 +170,35 @@ namespace GitHubLabeler
                 Description = issue.Body
             };
 
-            var predictedLabel = Predict(corefxIssue);
+            _fullPredictions = Predict(corefxIssue);
 
-            return predictedLabel;
+            return _fullPredictions;
         }
 
-        public string Predict(GitHubIssue issue)
-        {          
+        public FullPrediction[] Predict(GitHubIssue issue)
+        {
             var prediction = _predEngine.Predict(issue);
 
-            return prediction.Area;
+            var fullPredictions = GetBestThreePredictions(prediction);
+
+            return fullPredictions;
         }
 
-        private void ApplyLabel(Issue issue, string label)
+        private void ApplyLabels(Issue issue, FullPrediction[] fullPredictions)
         {
             var issueUpdate = new IssueUpdate();
-            issueUpdate.AddLabel(label);
 
-            _client.Issue.Update(_repoOwner, _repoName, issue.Number, issueUpdate);
+            //assign labels in GITHUB only if predicted score of all predictions is > 30%
+            foreach (var fullPrediction in fullPredictions)
+            {
+                if (fullPrediction.Score >= 0.3)
+                {
+                    issueUpdate.AddLabel(fullPrediction.PredictedLabel);
+                    _client.Issue.Update(_repoOwner, _repoName, issue.Number, issueUpdate);
 
-            Console.WriteLine($"Issue {issue.Number} : \"{issue.Title}\" \t was labeled as: {label}");
+                    Console.WriteLine($"Issue {issue.Number} : \"{issue.Title}\" \t was labeled as: {fullPredictions[0].PredictedLabel}");
+                }
+            }
         }
-    }
+     }
 }

--- a/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
+++ b/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
@@ -154,6 +154,8 @@ namespace GitHubLabeler
 
         private static async Task PredictLabelsAndUpdateGitHub(string ModelPath)
         {
+            Console.WriteLine(".............Retrieving Issues from GITHUB repo, predicting label/s and assigning predicted label/s......");
+
             var token = Configuration["GitHubToken"];
             var repoOwner = Configuration["GitHubRepoOwner"]; //IMPORTANT: This can be a GitHub User or a GitHub Organization
             var repoName = Configuration["GitHubRepoName"];


### PR DESCRIPTION
1.Created a class to have Prediction values like score, label and matchingSchemaIndex
2.Added Score filed in GitHubIssuePrediction class.
3.Changed the existing code like ApplyingLabels,PredictLabels in Labeler class.
4.Added new method in Labeler class to find the best 3 scores and return their indexes so that we can get the labels of those matched indexes from slotnames.