### PR TITLE
Revert "Turn off supportSparse in GitHubLabeler sample"

### DIFF
--- a/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
+++ b/samples/csharp/end-to-end-apps/MulticlassClassification-GitHubLabeler/GitHubLabeler/GitHubLabelerConsoleApp/Program.cs
@@ -57,7 +57,7 @@ namespace GitHubLabeler
             var mlContext = new MLContext(seed: 1);
 
             // STEP 1: Common data loading configuration
-            var trainingDataView = mlContext.Data.ReadFromTextFile<GitHubIssue>(DataSetLocation, hasHeader: true, separatorChar:'\t', supportSparse: false);
+            var trainingDataView = mlContext.Data.ReadFromTextFile<GitHubIssue>(DataSetLocation, hasHeader: true, separatorChar:'\t');
              
             // STEP 2: Common data process configuration with pipeline data transformations
             var dataProcessPipeline = mlContext.Transforms.Conversion.MapValueToKey(outputColumnName: DefaultColumnNames.Label,inputColumnName:nameof(GitHubIssue.Area))


### PR DESCRIPTION
Reverts dotnet/machinelearning-samples#257

This is no longer needed, as:
- https://github.com/dotnet/machinelearning/pull/2630 made supportSparse default to false.  And even if it wasn't changed....
- https://github.com/dotnet/machinelearning/pull/2579 made supportSparse faster when it is true, in particular when the debugger is attached.

cc: @CESARDELATORRE 