### PR TITLE
Fix icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ At the end of the survey, you can leave your name and e-mail address (optional) 
 
 There are two types of samples/apps in the repo:
 
-* ![](https://github.com/dotnet/machinelearning-samples/blob/features/samples-new-api/images/app-type-getting-started.png)  Getting Started - ML.NET code focused samples for each ML task or area, usually implemented as simple console apps.
+* <img src="images/app-type-getting-started.png" alt="Getting started icon">  Getting Started - ML.NET code focused samples for each ML task or area, usually implemented as simple console apps.
 
-* ![](https://github.com/dotnet/machinelearning-samples/blob/features/samples-new-api/images/app-type-e2e.png)  End-End apps - Real world examples of web, desktop, mobile, and other applications infused with Machine Learning using ML.NET
+* <img src="images/app-type-e2e.png" alt="End-to-end app icon">  End-End apps - Real world examples of web, desktop, mobile, and other applications infused with Machine Learning using ML.NET
 
 The official ML.NET samples are divided in multiple categories depending on the scenario and machine learning problem/task, accessible through the following table:
 


### PR DESCRIPTION
The icons in the readme are broken. I fixed the app icons, but the icon in front of ML.NET still needs to be taken care of. It points to this site https://dotnet.visualstudio.com/_apis/public/build/definitions/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/22/badge returning "Build pipeline 22 was not found".

![Screenshot from 2019-04-14 16-07-17](https://user-images.githubusercontent.com/7271470/56094022-96a2be80-5ecf-11e9-9c33-908ed53e5034.png)
