### PR TITLE
Fixed typos in documentation

### DIFF
--- a/samples/csharp/end-to-end-apps/ScalableMLModelOnWebAPI-IntegrationPkg/README.md
+++ b/samples/csharp/end-to-end-apps/ScalableMLModelOnWebAPI-IntegrationPkg/README.md
@@ -1,6 +1,6 @@
 
 
-# ASP.NET Core WebAPI sample optimized for scalability and performance when runnig/scoring an ML.NET model (Using the new '.NET Core Integration Package')
+# ASP.NET Core WebAPI sample optimized for scalability and performance when running/scoring an ML.NET model (Using the new '.NET Core Integration Package')
 
 
 | ML.NET version | Status                        | App Type    | Data type | Scenario            | ML Task                   | Algorithms                  |
@@ -10,7 +10,7 @@
 
 **This posts explains how to optimize your code when running an ML.NET model on an ASP.NET Core WebAPI service.** The code would be very similar when running it on an ASP.NET Core MVC or Razor web app, too.
 
-This code has been very much simplified by **using a new '.NET Core Integration Package'** that the .NET team has created (in experimental state) which implementes all the 'plumbing' for doing object pooling for the PredictionEngine.
+This code has been very much simplified by **using a new '.NET Core Integration Package'** that the .NET team has created (in experimental state) which implements all the 'plumbing' for doing object pooling for the PredictionEngine.
 
 
 # Goal
@@ -21,7 +21,7 @@ This code has been very much simplified by **using a new '.NET Core Integration 
 SamplePrediction prediction = _predictionEnginePool.Predict(sampleData);
 ```
 
-As simple as a single line. The object _predictionEnginePool will be injected in the controller's constructor or into you custom class. 
+As simple as a single line. The object _predictionEnginePool will be injected in the controller's constructor or into your custom class. 
 
 Internally, it is optimized so the object dependencies are cached and shared across Http requests with minimum overhead when creating those objects.
 
@@ -31,7 +31,7 @@ The problem running/scoring an ML.NET model in multi-threaded applications comes
 
 # Solution
 
-## Use the new '.NET Core Integration Pakage' that implements Object Pooling of PredictionEngine objects for you 
+## Use the new '.NET Core Integration Package' that implements Object Pooling of PredictionEngine objects for you 
 
 **'.NET Core Integration Package' NuGet feed**
 
@@ -58,7 +58,7 @@ SamplePrediction prediction = _predictionEnginePool.Predict(sampleData);
 
 It is that simple.
 
-For a much more detailed explanation of a PredictionEngine Object Pool comparable to the implementaion done in the new '.NET Core Integration Package', including design diagrams, read the following blog post:
+For a much more detailed explanation of a PredictionEngine Object Pool comparable to the implementation done in the new '.NET Core Integration Package', including design diagrams, read the following blog post:
 
 **Detailed Blog Post** for further background documentation:
 

--- a/samples/csharp/end-to-end-apps/ScalableMLModelOnWebAPI/README.md
+++ b/samples/csharp/end-to-end-apps/ScalableMLModelOnWebAPI/README.md
@@ -1,6 +1,6 @@
 
 
-# ASP.NET Core WebAPI sample optimized for scalability and performance when runnig/scoring an ML.NET model
+# ASP.NET Core WebAPI sample optimized for scalability and performance when running/scoring an ML.NET model
 
 
 | ML.NET version | Status                        | App Type    | Data type | Scenario            | ML Task                   | Algorithms                  |
@@ -25,7 +25,7 @@ For a much more detailed explanation, including design diagrams, read the follow
 SamplePrediction prediction = _modelEngine.Predict(sampleData);
 ```
 
-As simple as a single line. The object _modelEngine will be injected in the controller's constructor or into you custom class. 
+As simple as a single line. The object _modelEngine will be injected in the controller's constructor or into your custom class. 
 
 Internally, it is optimized so the object dependencies are cached and shared across Http requests with minimum overhead when creating those objects.
 
@@ -37,7 +37,7 @@ The problem running/scoring an ML.NET model in multi-threaded applications comes
 
 ## Use Object Pooling for PredictionEngine objects  
 
-Since a PredictionEngine object cannot be singleton because it is not 'thread safe', a good solution for being able to have 'ready to use' PredictionEngine objects  is to use an object pooling-based approach.
+Since a PredictionEngine object cannot be singleton because it is not 'thread safe', a good solution for being able to have 'ready to use' PredictionEngine objects is to use an object pooling-based approach.
 
 When it is necessary to work with a number of objects that are particularly expensive to instantiate and each object is only needed for a short period of time, the performance of an entire application may be adversely affected. This issue will happen if you instantiate a Prediction Engine object whenever you get an Http request.
 
@@ -45,4 +45,4 @@ An object pool design pattern can be very effective in such cases.
 
 The [object pool pattern](https://en.wikipedia.org/wiki/Object_pool_pattern) is a design pattern that uses a set of initialized objects kept ready to use (a 'pool') rather than allocating and destroying them on demand. 
 
-This solution's implementation is based on a higher level custom class (named **MLModelEngine**) which is instantiated as singleton and creates the needed infrastructure for such an object pool solution.
+This solution's implementation is based on a higher-level custom class (named **MLModelEngine**) which is instantiated as singleton and creates the needed infrastructure for such an object pool solution.

--- a/samples/csharp/end-to-end-apps/ScalableSentimentAnalysisBlazorWebApp/README.md
+++ b/samples/csharp/end-to-end-apps/ScalableSentimentAnalysisBlazorWebApp/README.md
@@ -1,6 +1,6 @@
 
 
-# SENTIMENT ANALYSIS: Blazor sample (ASP.NET Core 3.0 Preview) optimized for scalability and performance when runnig/scoring an ML.NET model (Using the new '.NET Core Integration Package for ML.NET')
+# SENTIMENT ANALYSIS: Blazor sample (ASP.NET Core 3.0 Preview) optimized for scalability and performance when running/scoring an ML.NET model (Using the new '.NET Core Integration Package for ML.NET')
 
 
 | ML.NET version | Status                        | App Type    | Data type | Scenario            | ML Task                   | Algorithms                  |
@@ -45,7 +45,7 @@ The problem running/scoring an ML.NET model in multi-threaded applications comes
 
 # Solution
 
-## Use the new '.NET Core Integration Pakage' that implements Object Pooling of PredictionEngine objects for you 
+## Use the new '.NET Core Integration Package' that implements Object Pooling of PredictionEngine objects for you 
 
 **'.NET Core Integration Package' NuGet**
 
@@ -73,7 +73,7 @@ SamplePrediction prediction = _predictionEnginePool.Predict(sampleData);
 
 It is that simple.
 
-For a much more detailed explanation of a PredictionEngine Object Pool comparable to the implementaion done in the new '.NET Core Integration Package', including design diagrams, read the following blog post:
+For a much more detailed explanation of a PredictionEngine Object Pool comparable to the implementation done in the new '.NET Core Integration Package', including design diagrams, read the following blog post:
 
 **Detailed Blog Post** for further documentation:
 


### PR DESCRIPTION
Noticed a few typos in some of the readme files while looking at the examples.