### PR TITLE
Log Exception.ToString() instead of Exception.Message

### DIFF
--- a/samples/csharp/end-to-end-apps/Regression-SalesForecast/src/eShopForecastModelsTrainer/Program.cs
+++ b/samples/csharp/end-to-end-apps/Regression-SalesForecast/src/eShopForecastModelsTrainer/Program.cs
@@ -17,11 +17,11 @@ namespace eShopForecastModelsTrainer
 
         static void Main(string[] args)
         {
-            
+
             try
             {
                 MLContext mlContext = new MLContext(seed: 1);  //Seed set to any number so you have a deterministic environment
-                
+
                 ProductModelHelper.TrainAndSaveModel(mlContext, ProductDataPath);
                 ProductModelHelper.TestPrediction(mlContext);
 
@@ -30,7 +30,7 @@ namespace eShopForecastModelsTrainer
             }
             catch (Exception ex)
             {
-                ConsoleWriteException(ex.Message);
+                ConsoleWriteException(ex.ToString());
             }
             ConsolePressAnyKey();
         }

--- a/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Predict/Program.cs
+++ b/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Predict/Program.cs
@@ -30,7 +30,7 @@ namespace CustomerSegmentation
                 clusteringModelScorer.CreateCustomerClusters();
             } catch (Exception ex)
             {
-                Common.ConsoleHelper.ConsoleWriteException(ex.Message);
+                Common.ConsoleHelper.ConsoleWriteException(ex.ToString());
             }
 
             Common.ConsoleHelper.ConsolePressAnyKey();

--- a/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Train/Program.cs
+++ b/samples/csharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Train/Program.cs
@@ -41,13 +41,13 @@ namespace CustomerSegmentation
                 //STEP 2: Configure data transformations in pipeline
                 var dataProcessPipeline = mlContext.Transforms.ProjectToPrincipalComponents(outputColumnName: "PCAFeatures", inputColumnName: "Features", rank: 2)
                  .Append(mlContext.Transforms.Categorical.OneHotEncoding(outputColumnName: "LastNameKey", inputColumnName: nameof(PivotData.LastName), OneHotEncodingEstimator.OutputKind.Indicator));
-                
 
-                // (Optional) Peek data in training DataView after applying the ProcessPipeline's transformations  
+
+                // (Optional) Peek data in training DataView after applying the ProcessPipeline's transformations
                 Common.ConsoleHelper.PeekDataViewInConsole(mlContext, pivotDataView, dataProcessPipeline, 10);
                 Common.ConsoleHelper.PeekVectorColumnDataInConsole(mlContext, "Features", pivotDataView, dataProcessPipeline, 10);
 
-                //STEP 3: Create the training pipeline                
+                //STEP 3: Create the training pipeline
                 var trainer = mlContext.Clustering.Trainers.KMeans(featureColumnName: "Features", numberOfClusters: 3);
                 var trainingPipeline = dataProcessPipeline.Append(trainer);
 
@@ -69,11 +69,11 @@ namespace CustomerSegmentation
             }
             catch (Exception ex)
             {
-                Common.ConsoleHelper.ConsoleWriteException(ex.Message);
+                Common.ConsoleHelper.ConsoleWriteException(ex.ToString());
             }
 
             Common.ConsoleHelper.ConsolePressAnyKey();
-           
+
         }
         public static string GetAbsolutePath(string relativePath)
         {

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_TensorFlow/ImageClassification/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_TensorFlow/ImageClassification/Program.cs
@@ -25,7 +25,7 @@ namespace ImageClassification
             }
             catch (Exception ex)
             {
-                ConsoleHelpers.ConsoleWriteException(ex.Message);
+                ConsoleHelpers.ConsoleWriteException(ex.ToString());
             }
 
             ConsoleHelpers.ConsolePressAnyKey();

--- a/samples/csharp/getting-started/DeepLearning_ObjectDetection_Onnx/ObjectDetectionConsoleApp/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_ObjectDetection_Onnx/ObjectDetectionConsoleApp/Program.cs
@@ -21,7 +21,7 @@ namespace ObjectDetection
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.ToString());
             }
 
             Console.WriteLine("========= End of Process..Hit any Key ========");

--- a/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Predict/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Predict/Program.cs
@@ -24,7 +24,7 @@ namespace ImageClassification.Predict
             }
             catch (Exception ex)
             {
-                ConsoleWriteException(ex.Message);
+                ConsoleWriteException(ex.ToString());
             }
 
             ConsolePressAnyKey();

--- a/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Train/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Train/Program.cs
@@ -25,7 +25,7 @@ namespace ImageClassification.Train
             }
             catch (Exception ex)
             {
-                ConsoleWriteException(ex.Message);
+                ConsoleWriteException(ex.ToString());
             }
 
             ConsolePressAnyKey();

--- a/samples/csharp/getting-started/MulticlassClassification_MNIST/MNIST/Program.cs
+++ b/samples/csharp/getting-started/MulticlassClassification_MNIST/MNIST/Program.cs
@@ -37,7 +37,7 @@ namespace mnist
             {
                 // STEP 1: Common data loading configuration
                 var trainData = mlContext.Data.LoadFromTextFile(path: TrainDataPath,
-                        columns : new[] 
+                        columns : new[]
                         {
                             new TextLoader.Column(nameof(InputData.PixelValues), DataKind.Single, 0, 63),
                             new TextLoader.Column("Number", DataKind.Single, 64)
@@ -46,7 +46,7 @@ namespace mnist
                         separatorChar : ','
                         );
 
-                
+
                 var testData = mlContext.Data.LoadFromTextFile(path: TestDataPath,
                         columns: new[]
                         {
@@ -83,7 +83,7 @@ namespace mnist
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.ToString());
                 //return null;
             }
         }
@@ -104,7 +104,7 @@ namespace mnist
 
             // Create prediction engine related to the loaded trained model
             var predEngine = mlContext.Model.CreatePredictionEngine<InputData, OutPutData>(trainedModel);
-            
+
             var resultprediction1 = predEngine.Predict(SampleMNISTData.MNIST1);
 
             Console.WriteLine($"Actual: 1     Predicted probability:       zero:  {resultprediction1.Score[0]:0.####}");
@@ -118,7 +118,7 @@ namespace mnist
             Console.WriteLine($"                                           eight: {resultprediction1.Score[8]:0.####}");
             Console.WriteLine($"                                           nine:  {resultprediction1.Score[9]:0.####}");
             Console.WriteLine();
-                       
+
             var resultprediction2 = predEngine.Predict(SampleMNISTData.MNIST2);
 
             Console.WriteLine($"Actual: 7     Predicted probability:       zero:  {resultprediction2.Score[0]:0.####}");

--- a/samples/fsharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Predict/Program.fs
+++ b/samples/fsharp/getting-started/Clustering_CustomerSegmentation/CustomerSegmentation.Predict/Program.fs
@@ -8,7 +8,7 @@ open System.Diagnostics
 
 let dataRoot = FileInfo(System.Reflection.Assembly.GetExecutingAssembly().Location)
 
-let printHeader lines = 
+let printHeader lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Yellow
     printfn " "
@@ -16,8 +16,8 @@ let printHeader lines =
     let maxLength = lines |> Seq.map (fun x -> x.Length) |> Seq.max
     printfn "%s" (String('#', maxLength))
     Console.ForegroundColor <- defaultColor
-    
-let printExn lines = 
+
+let printExn lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Red
     printfn " "
@@ -25,30 +25,30 @@ let printExn lines =
     printfn "#########"
     Console.ForegroundColor <- defaultColor
     lines |> Seq.iter (printfn "%s")
-    
-let savePivotData offersCsv transactionsCsv pivotCsv = 
+
+let savePivotData offersCsv transactionsCsv pivotCsv =
     printHeader ["Preprocess input files"]
     printfn "Offers file: %s"  offersCsv
     printfn "Transactions file: %s"  transactionsCsv
-    let pivotData = 
+    let pivotData =
         File.ReadAllLines(transactionsCsv)
         |> Seq.skip 1 //skip header
-        |> Seq.map 
+        |> Seq.map
             (fun x ->
                 let fields = x.Split ','
                 fields.[0] , int fields.[1] // Name, Offer #
             )
         |> Seq.groupBy fst
-        |> Seq.map 
-            (fun (k, xs) -> 
+        |> Seq.map
+            (fun (k, xs) ->
                 let offers = xs |> Seq.map snd |> Set.ofSeq
                 [
                     yield! Seq.init 32 (fun i -> if Seq.contains (i + 1) offers then "1" else "0")
                     yield k
-                ] 
+                ]
                 |> String.concat ","
             )
-    File.WriteAllLines(pivotCsv, 
+    File.WriteAllLines(pivotCsv,
         seq {
             yield [
                 yield! Seq.init 32 (fun i -> sprintf "C%d" (i + 1))
@@ -56,9 +56,9 @@ let savePivotData offersCsv transactionsCsv pivotCsv =
             ] |> String.concat ","
             yield! pivotData
         })
-    
+
 [<CLIMutable>]
-type ClusteringPrediction = 
+type ClusteringPrediction =
     {
         [<ColumnName("PredictedLabel")>]
         SelectedClusterId : uint32
@@ -70,22 +70,22 @@ type ClusteringPrediction =
         LastName : string
     }
 
-let savePlot (predictions : ClusteringPrediction []) (plotSvg : string) = 
+let savePlot (predictions : ClusteringPrediction []) (plotSvg : string) =
     printHeader ["Plot Customer Segmentation"]
     let pm = PlotModel(Title = "Customer Segmentation", IsLegendVisible = true)
     predictions
     |> Seq.groupBy (fun x -> x.SelectedClusterId)
     |> Seq.sortBy fst
-    |> Seq.iter 
-        (fun (cluster,xs) -> 
-            let scatter = 
+    |> Seq.iter
+        (fun (cluster,xs) ->
+            let scatter =
                 ScatterSeries
-                    (MarkerType = MarkerType.Circle, 
-                     MarkerStrokeThickness = 2.0, 
-                     Title = sprintf "Cluster: %d" cluster, 
+                    (MarkerType = MarkerType.Circle,
+                     MarkerStrokeThickness = 2.0,
+                     Title = sprintf "Cluster: %d" cluster,
                      RenderInLegend = true )
-            xs 
-            |> Seq.map (fun x -> ScatterPoint(double x.Location.[0], double x.Location.[1])) 
+            xs
+            |> Seq.map (fun x -> ScatterPoint(double x.Location.[0], double x.Location.[1]))
             |> scatter.Points.AddRange
             pm.Series.Add scatter
         )
@@ -104,29 +104,29 @@ let main _argv =
     let plotCsv = Path.Combine(assetsPath, "outputs", "customerSegmentation.csv")
     try
         let mlContext = MLContext(seed = Nullable 1);  //Seed set to any number so you have a deterministic result
-        
+
         //Create the clusters: Create data files and plot a char
-        let model, inputSchema = 
+        let model, inputSchema =
             use f = new FileStream(modelZipFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)
             mlContext.Model.Load(f)
-        
-        let data = 
+
+        let data =
             mlContext.Data.LoadFromTextFile(
                 pivotCsv,
-                columns = 
-                    [| 
+                columns =
+                    [|
                         TextLoader.Column("Features", DataKind.Single, [| TextLoader.Range(0, Nullable 31) |])
                         TextLoader.Column("LastName", DataKind.String, 32)
                     |],
                 hasHeader = true,
                 separatorChar = ',')
-        
+
         //Apply data transformation to create predictions/clustering
         let predictions = mlContext.Data.CreateEnumerable<ClusteringPrediction>(model.Transform(data),false) |> Seq.toArray
 
         //Generate data files with customer data grouped by clusters
         printHeader ["CSV Customer Segmentation"]
-        File.WriteAllLines(plotCsv, 
+        File.WriteAllLines(plotCsv,
             seq {
                 yield "LastName,SelectedClusterId"
                 yield! predictions |> Seq.map (fun x -> sprintf "%s,%d" x.LastName x.SelectedClusterId)
@@ -141,9 +141,9 @@ let main _argv =
         |> Process.Start
         |> ignore
 
-    with 
-    | ex -> printExn [ex.Message]
-    
+    with
+    | ex -> printExn [ex.ToString()]
+
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Green
     printfn " "

--- a/samples/fsharp/getting-started/DeepLearning_ImageClassification_TensorFlow/ImageClassification/Program.fs
+++ b/samples/fsharp/getting-started/DeepLearning_ImageClassification_TensorFlow/ImageClassification/Program.fs
@@ -14,7 +14,7 @@ let channelsLast = true
 let OutputTensorName = "softmax2"
 
 [<CLIMutable>]
-type ImageNetData = 
+type ImageNetData =
     {
         [<LoadColumn(0)>]
         ImagePath : string
@@ -35,8 +35,8 @@ type ImageNetDataProbability =
 type ImageNetPipeline =
     {
         ImagePath : string
-        Label : string 
-        PredictedLabelValue : string 
+        Label : string
+        PredictedLabelValue : string
         Score : float32 []
         softmax2_pre_activation : float32 []
     }
@@ -48,7 +48,7 @@ type ImageNetPrediction =
     }
 
 
-let printImagePrediction (x : ImageNetPipeline) = 
+let printImagePrediction (x : ImageNetPipeline) =
     let defaultForeground = Console.ForegroundColor
     let labelColor = ConsoleColor.Magenta
     let probColor = ConsoleColor.Blue
@@ -66,7 +66,7 @@ let printImagePrediction (x : ImageNetPipeline) =
     Console.ForegroundColor <- defaultForeground;
     printfn ""
 
-let printHeader lines = 
+let printHeader lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Yellow
     printfn " "
@@ -74,8 +74,8 @@ let printHeader lines =
     let maxLength = lines |> Seq.map (fun x -> x.Length) |> Seq.max
     printfn "%s" (String('#', maxLength))
     Console.ForegroundColor <- defaultColor
-    
-let printExn lines = 
+
+let printExn lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Red
     printfn " "
@@ -84,8 +84,8 @@ let printExn lines =
     Console.ForegroundColor <- defaultColor
     lines |> Seq.iter (printfn "%s")
 
-let printImageNetProb (x : ImageNetDataProbability) = 
-    
+let printImageNetProb (x : ImageNetDataProbability) =
+
     let defaultForeground = Console.ForegroundColor
     let labelColor = ConsoleColor.Magenta
     let probColor = ConsoleColor.Blue
@@ -101,7 +101,7 @@ let printImageNetProb (x : ImageNetDataProbability) =
     printf "%s" x.Label
     Console.ForegroundColor <- defaultForeground
     printf " predicted as "
-    if x.Label = x.PredictedLabel then 
+    if x.Label = x.PredictedLabel then
         Console.ForegroundColor <- exactLabel
         printf "%s" x.PredictedLabel
     else
@@ -114,7 +114,7 @@ let printImageNetProb (x : ImageNetDataProbability) =
     Console.ForegroundColor <- defaultForeground
     printfn ""
 
-let score dataLocation imagesFolder inputModelLocation labelsTxt = 
+let score dataLocation imagesFolder inputModelLocation labelsTxt =
     printHeader ["Read model"]
     printfn "Model location: %s" inputModelLocation
     printfn "Images folder: %s" imagesFolder
@@ -137,16 +137,16 @@ let score dataLocation imagesFolder inputModelLocation labelsTxt =
     printfn "Labels file: %s" labelsTxt
 
     let labels = File.ReadAllLines(labelsTxt)
-    
+
     File.ReadAllLines(dataLocation)
     |> Seq.map (fun x -> let fields = x.Split '\t' in {ImagePath = Path.Combine(imagesFolder, fields.[0]); Label = fields.[1]})
-    |> Seq.map 
+    |> Seq.map
         (fun sample ->
             let preds = predictionEngine.Predict(sample).PredictedLabels
             let bestLabelIndex =
                 preds
-                |> Seq.mapi (fun i x -> i, x) 
-                |> Seq.maxBy snd 
+                |> Seq.mapi (fun i x -> i, x)
+                |> Seq.maxBy snd
                 |> fst
             {
                 PredictedLabel = labels.[bestLabelIndex]
@@ -156,7 +156,7 @@ let score dataLocation imagesFolder inputModelLocation labelsTxt =
             }
         )
     |> Seq.iter printImageNetProb
-    
+
 [<EntryPoint>]
 let main _argv =
     let assetsPath = Path.Combine(dataRoot.Directory.FullName, @"..\..\..\assets")
@@ -167,9 +167,9 @@ let main _argv =
 
     try
         score tagsTsv imagesFolder inceptionPb labelsTxt
-    with 
-    | e -> printExn [e.Message]
-    
+    with
+    | e -> printExn [e.ToString()]
+
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Green
     printfn " "

--- a/samples/fsharp/getting-started/DeepLearning_ObjectDetection_Onnx/ObjectDetectionConsoleApp/Program.fs
+++ b/samples/fsharp/getting-started/DeepLearning_ObjectDetection_Onnx/ObjectDetectionConsoleApp/Program.fs
@@ -14,14 +14,14 @@ let InputTensorName = "image"
 let OutputTensorName = "grid"
 
 
-type YoloBoundingBox = 
+type YoloBoundingBox =
     {
-        Label : string 
-        X : float32 
-        Y : float32 
-        Height : float32 
-        Width : float32 
-        Confidence : float32 
+        Label : string
+        X : float32
+        Y : float32
+        Height : float32
+        Width : float32
+        Confidence : float32
     }
     member x.Rect = RectangleF(x.X, x.Y, x.Width, x.Height)
 
@@ -35,7 +35,7 @@ type ImageNetData =
     }
 
 [<CLIMutable>]
-type ImageNetPrediction = 
+type ImageNetPrediction =
     {
         [<ColumnName(OutputTensorName)>]
         PredictedLabels : float32[]
@@ -49,31 +49,31 @@ let imagesFolder = Path.Combine(assetsPath,"images")
 let tagsTsv = Path.Combine(assetsPath,"images", "tags.tsv")
 
 
-[<Literal>] 
+[<Literal>]
 let ROW_COUNT = 13
-[<Literal>] 
+[<Literal>]
 let COL_COUNT = 13
-[<Literal>] 
+[<Literal>]
 let CHANNEL_COUNT = 125
-[<Literal>] 
+[<Literal>]
 let BOXES_PER_CELL = 5
-[<Literal>] 
+[<Literal>]
 let BOX_INFO_FEATURE_COUNT = 5
-[<Literal>] 
+[<Literal>]
 let CLASS_COUNT = 20
-[<Literal>] 
+[<Literal>]
 let CELL_WIDTH = 32.f
-[<Literal>] 
+[<Literal>]
 let CELL_HEIGHT = 32.f
 let channelStride = ROW_COUNT * COL_COUNT
 let anchors = [|1.08f; 1.19f; 3.42f; 4.41f; 6.63f; 11.38f; 9.42f; 5.11f; 16.62f; 10.52f|]
-let labels = 
-    [|"aeroplane"; "bicycle"; "bird"; "boat"; "bottle"; "bus"; "car"; 
-      "cat"; "chair"; "cow"; "diningtable"; "dog"; "horse"; "motorbike"; 
+let labels =
+    [|"aeroplane"; "bicycle"; "bird"; "boat"; "bottle"; "bus"; "car";
+      "cat"; "chair"; "cow"; "diningtable"; "dog"; "horse"; "motorbike";
       "person"; "pottedplant"; "sheep"; "sofa"; "train"; "tvmonitor" |]
 
 let sigmoid x = let k = exp x in k / (1.f + k)
-let softmax x = 
+let softmax x =
     let mx = x |> Array.max
     let expX = x |> Array.map (fun i -> exp (i - mx))
     let sm = expX |> Array.sum
@@ -82,7 +82,7 @@ let softmax x =
 let intersectionOverUnion (a : RectangleF) (b : RectangleF) =
     let areaA = a.Width * a.Height
     let areaB = b.Width * b.Height
-    if areaA <= 0.f || areaB <= 0.f then 
+    if areaA <= 0.f || areaB <= 0.f then
         0.f
     else
         let minX = max a.Left b.Left
@@ -91,15 +91,15 @@ let intersectionOverUnion (a : RectangleF) (b : RectangleF) =
         let maxY = min a.Bottom b.Bottom
         let intersectionArea = (max (maxY - minY) 0.f) * max (maxX - minX) 0.f
         intersectionArea / (areaA + areaB - intersectionArea)
-    
-let parseOutputs threshold (outputs : float32 []) = 
+
+let parseOutputs threshold (outputs : float32 []) =
     let boxes = ResizeArray()
-    for cy = 0 to ROW_COUNT - 1 do 
-        for cx = 0 to COL_COUNT - 1 do 
-            for b = 0 to BOXES_PER_CELL - 1 do 
+    for cy = 0 to ROW_COUNT - 1 do
+        for cx = 0 to COL_COUNT - 1 do
+            for b = 0 to BOXES_PER_CELL - 1 do
                 let get channel = outputs.[channel*channelStride + cy*COL_COUNT + cx]
                 let channel = b * (CLASS_COUNT + BOX_INFO_FEATURE_COUNT)
-                let tx = get channel 
+                let tx = get channel
                 let ty = get (channel + 1)
                 let tw = get (channel + 2)
                 let th = get (channel + 3)
@@ -109,14 +109,14 @@ let parseOutputs threshold (outputs : float32 []) =
                 let width = exp tw * CELL_WIDTH * anchors.[b*2]
                 let height = exp th * CELL_HEIGHT * anchors.[b*2 + 1]
                 let confidence = sigmoid tc
-                if confidence >= threshold then 
-                    let classes = 
+                if confidence >= threshold then
+                    let classes =
                         let classOffset = channel + BOX_INFO_FEATURE_COUNT;
                         Array.init CLASS_COUNT (fun i -> get (i + classOffset))
                     let results = softmax classes |> Array.mapi (fun i x -> (i,x))
-                    let topClass = results |> Array.maxBy snd |> fst 
+                    let topClass = results |> Array.maxBy snd |> fst
                     let topScore = results |> Array.maxBy snd |> (fun (_, x) -> x * confidence)
-                    if topScore >= threshold then 
+                    if topScore >= threshold then
                         boxes.Add {
                                 Confidence = topScore
                                 X = (x - width / 2.f)
@@ -126,34 +126,34 @@ let parseOutputs threshold (outputs : float32 []) =
                                 Label = labels.[topClass] } |> ignore
     boxes.ToArray()
 
-let nonMaxSuppress limit threshold boxes = 
-    let rec loop count acc l = 
-        match l with 
+let nonMaxSuppress limit threshold boxes =
+    let rec loop count acc l =
+        match l with
         | [] -> acc
         | (a : YoloBoundingBox) :: t ->
-            let acc = a :: acc 
-            let count = count + 1 
-            if count >= limit then 
+            let acc = a :: acc
+            let count = count + 1
+            if count >= limit then
                 acc
             else
-                t 
+                t
                 |> List.filter (fun b ->intersectionOverUnion a.Rect b.Rect <= threshold)
                 |> loop count acc
-    boxes 
-    |> Array.sortByDescending (fun x -> x.Confidence) 
+    boxes
+    |> Array.sortByDescending (fun x -> x.Confidence)
     |> Array.toList
     |> loop 0 []
 
 
-try 
+try
     let mlContext = MLContext()
-    let model = 
+    let model =
         printfn "Read model"
         printfn "Model location: %s" modelFilePath
         printfn "Images folder: %s" imagesFolder
         printfn "Default parameters: image size=(%d,%d)" imageWidth imageHeight
         let data = mlContext.Data.LoadFromTextFile<ImageNetData>(imagesFolder, hasHeader=true)
-        let pipeline = 
+        let pipeline =
             EstimatorChain()
                 .Append(mlContext.Transforms.LoadImages("image", imageFolder = imagesFolder, inputColumnName = "ImagePath"))
                 .Append(mlContext.Transforms.ResizeImages("image", imageWidth = imageWidth, imageHeight = imageHeight, inputColumnName = "image"))
@@ -167,28 +167,28 @@ try
     printfn "=====Identify the objects in the images====="
     printfn ""
 
-    File.ReadAllLines(tagsTsv) 
-    |> Seq.map 
-        (fun x -> 
+    File.ReadAllLines(tagsTsv)
+    |> Seq.map
+        (fun x ->
             let a = x.Split '\t'
             {ImagePath = Path.Combine(imagesFolder, a.[0]); Label = a.[1]}
         )
-    |> Seq.iter 
+    |> Seq.iter
         (fun sample ->
             let probs = model.Predict(sample).PredictedLabels
-            let boundingBoxes = parseOutputs 0.3f probs 
+            let boundingBoxes = parseOutputs 0.3f probs
             let filteredBoxes = nonMaxSuppress 5 0.5f boundingBoxes
 
             printfn ".....The objects in the image %s are detected as below...."  sample.Label
-            filteredBoxes 
-            |> Seq.iter 
+            filteredBoxes
+            |> Seq.iter
                 (fun fbox ->
                     printfn "%s and its Confidence score: %0.7f" fbox.Label fbox.Confidence
                 )
             printfn ""
         )
  with
- | e -> printfn "%s" e.Message
- 
+ | e -> printfn "%s" (e.ToString())
+
 printfn "========= End of Process. Hit any Key ========"
 Console.ReadLine() |> ignore

--- a/samples/fsharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Predict/Program.fs
+++ b/samples/fsharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Predict/Program.fs
@@ -14,7 +14,7 @@ let channelsLast = true
 let OutputTensorName = "softmax2"
 
 [<CLIMutable>]
-type ImageNetData = 
+type ImageNetData =
     {
         [<LoadColumn(0)>]
         ImagePath : string
@@ -35,12 +35,12 @@ type ImageNetDataProbability =
 type ImageNetPrediction =
     {
         ImagePath : string
-        Label : string 
-        PredictedLabelValue : string 
+        Label : string
+        PredictedLabelValue : string
         Score : float32 []
     }
 
-let printImagePrediction (x : ImageNetPrediction) = 
+let printImagePrediction (x : ImageNetPrediction) =
     let defaultForeground = Console.ForegroundColor
     let labelColor = ConsoleColor.Magenta
     let probColor = ConsoleColor.Blue
@@ -58,7 +58,7 @@ let printImagePrediction (x : ImageNetPrediction) =
     Console.ForegroundColor <- defaultForeground;
     printfn ""
 
-let printHeader lines = 
+let printHeader lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Yellow
     printfn " "
@@ -66,8 +66,8 @@ let printHeader lines =
     let maxLength = lines |> Seq.map (fun x -> x.Length) |> Seq.max
     printfn "%s" (String('#', maxLength))
     Console.ForegroundColor <- defaultColor
-    
-let printExn lines = 
+
+let printExn lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Red
     printfn " "
@@ -76,8 +76,8 @@ let printExn lines =
     Console.ForegroundColor <- defaultColor
     lines |> Seq.iter (printfn "%s")
 
-let printImageNetProb (x : ImageNetDataProbability) = 
-    
+let printImageNetProb (x : ImageNetDataProbability) =
+
     let defaultForeground = Console.ForegroundColor
     let labelColor = ConsoleColor.Magenta
     let probColor = ConsoleColor.Blue
@@ -93,7 +93,7 @@ let printImageNetProb (x : ImageNetDataProbability) =
     printf "%s" x.Label
     Console.ForegroundColor <- defaultForeground
     printf " predicted as "
-    if x.Label = x.PredictedLabel then 
+    if x.Label = x.PredictedLabel then
         Console.ForegroundColor <- exactLabel
         printf "%s" x.PredictedLabel
     else
@@ -106,11 +106,11 @@ let printImageNetProb (x : ImageNetDataProbability) =
     Console.ForegroundColor <- defaultForeground
     printfn ""
 
-let classifyImages dataLocation imagesFolder modelLocation = 
+let classifyImages dataLocation imagesFolder modelLocation =
     printHeader ["Loading model"]
 
     let mlContext = MLContext(seed = Nullable 1)
-    let loadedModel, inputSchema = 
+    let loadedModel, inputSchema =
         use f = File.OpenRead(modelLocation)
         mlContext.Model.Load(f)
     printfn "Model loaded: %s" modelLocation
@@ -120,8 +120,8 @@ let classifyImages dataLocation imagesFolder modelLocation =
     File.ReadAllLines(dataLocation)
     |> Seq.map (fun x -> let fields = x.Split '\t' in {ImagePath = Path.Combine(imagesFolder, fields.[0]); Label = fields.[1]})
     |> Seq.iter (predictor.Predict >> printImagePrediction)
-        
-    
+
+
 [<EntryPoint>]
 let main _argv =
     let assetsPath = Path.Combine(dataRoot.Directory.FullName, @"..\..\..\assets")
@@ -131,9 +131,9 @@ let main _argv =
 
     try
         classifyImages tagsTsv imagesFolder imageClassifierZip
-    with 
-    | e -> printExn [e.Message]
-    
+    with
+    | e -> printExn [e.ToString()]
+
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Green
     printfn " "

--- a/samples/fsharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Train/Program.fs
+++ b/samples/fsharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Train/Program.fs
@@ -12,7 +12,7 @@ let scale = 1
 let channelsLast = true
 
 [<CLIMutable>]
-type ImageNetData = 
+type ImageNetData =
     {
         [<LoadColumn(0)>]
         ImagePath : string
@@ -23,13 +23,13 @@ type ImageNetData =
 type ImageNetPipeline =
     {
         ImagePath : string
-        Label : string 
-        PredictedLabelValue : string 
+        Label : string
+        PredictedLabelValue : string
         Score : float32 []
         softmax2_pre_activation : float32 []
     }
 
-let printImagePrediction (x : ImageNetPipeline) = 
+let printImagePrediction (x : ImageNetPipeline) =
     let defaultForeground = Console.ForegroundColor
     let labelColor = ConsoleColor.Magenta
     let probColor = ConsoleColor.Blue
@@ -47,7 +47,7 @@ let printImagePrediction (x : ImageNetPipeline) =
     Console.ForegroundColor <- defaultForeground;
     printfn ""
 
-let printHeader lines = 
+let printHeader lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Yellow
     printfn " "
@@ -55,8 +55,8 @@ let printHeader lines =
     let maxLength = lines |> Seq.map (fun x -> x.Length) |> Seq.max
     printfn "%s" (String('#', maxLength))
     Console.ForegroundColor <- defaultColor
-    
-let printExn lines = 
+
+let printExn lines =
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Red
     printfn " "
@@ -64,9 +64,9 @@ let printExn lines =
     printfn "#########"
     Console.ForegroundColor <- defaultColor
     lines |> Seq.iter (printfn "%s")
-    
 
-let buildAndTrainModel dataLocation imagesFolder inputModelLocation imageClassifierZip = 
+
+let buildAndTrainModel dataLocation imagesFolder inputModelLocation imageClassifierZip =
     printfn "Read model"
     printfn "Model location: %s" inputModelLocation
     printfn "Images folder: %s" imagesFolder
@@ -91,7 +91,7 @@ let buildAndTrainModel dataLocation imagesFolder inputModelLocation imageClassif
     let trainData = model.Transform(data)
     mlContext.Data.CreateEnumerable<_>(trainData, false, true)
     |> Seq.iter printImagePrediction
-    
+
     printHeader ["Classification metrics"]
     let metrics = mlContext.MulticlassClassification.Evaluate(trainData, labelColumnName = "LabelTokey", predictedLabelColumnName = "PredictedLabel")
     printfn "LogLoss is: %.15f" metrics.LogLoss
@@ -99,12 +99,12 @@ let buildAndTrainModel dataLocation imagesFolder inputModelLocation imageClassif
     |> Seq.map string
     |> String.concat " , "
     |> printfn "PerClassLogLoss is: %s"
-    
+
     printHeader ["Save model to local file"]
     let outFile = Path.Combine(dataRoot.Directory.FullName, imageClassifierZip)
-    if File.Exists outFile then 
+    if File.Exists outFile then
         File.Delete(outFile)
-    do 
+    do
         use f = File.OpenWrite(outFile)
         mlContext.Model.Save(model, trainData.Schema, f)
     printfn "Model saved: %s" outFile
@@ -118,9 +118,9 @@ let main _argv =
     let imageClassifierZip = Path.Combine(assetsPath, "outputs", "imageClassifier.zip")
     try
         buildAndTrainModel tagsTsv imagesFolder inceptionPb imageClassifierZip
-    with 
-    | e -> printExn [e.Message]
-    
+    with
+    | e -> printExn [e.ToString()]
+
     let defaultColor = Console.ForegroundColor
     Console.ForegroundColor <- ConsoleColor.Green
     printfn " "


### PR DESCRIPTION
Hi!

Thanks for the samples! The first thing I ran into, is only the exception's `Message` is logged or written to console. But that's not always enough. InnerException and Stacktrace helps a lot. For example:

```
EXCEPTION
#########
Splitter/consolidator worker encountered exception while consuming source data
```
There was a typo in the filename:
```
EXCEPTION
#########
System.InvalidOperationException: Splitter/consolidator worker encountered exception while consuming source data
 ---> System.InvalidOperationException: Image xtoaster2.png was not found.
```

Or 

```
EXCEPTION
#########
Index was outside the bounds of the array.
```
Stacktrace helps, checked the code at that line, and found the reason:
```
EXCEPTION
#########
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Program.classifyImages@121-23.Invoke(String x) in ........\Program.fs:line 121
```

I think the simplest thing is to use `ToString()`, that usually provides enough details.
Sorry about the white space changes. Are you OK with it as-is?