### PR TITLE
Fixed GetImagesData to only enumerate the jpg files

### DIFF
--- a/samples/csharp/getting-started/DeepLearning_ObjectDetection_Onnx/ObjectDetectionConsoleApp/OnnxModelScorer.cs
+++ b/samples/csharp/getting-started/DeepLearning_ObjectDetection_Onnx/ObjectDetectionConsoleApp/OnnxModelScorer.cs
@@ -94,7 +94,7 @@ namespace ObjectDetection
         private static IEnumerable<ImageNetData> GetImagesData(string folder)
         {
             List<ImageNetData> imagesList = new List<ImageNetData>();
-            string[] filePaths = Directory.GetFiles(folder);
+            string[] filePaths = Directory.GetFiles(folder, "*.jpg");
             foreach (var filePath in filePaths)
             {
                 ImageNetData imagedata = new ImageNetData { ImagePath = filePath, Label = Path.GetFileName(filePath) };


### PR DESCRIPTION
Fixes #3675

This bug was actually reported for the Mac. 

On the Mac, this specific bug doesn't repro if you make sure libgdiplus is installed and upgraded to the latest version. 

However, on both Mac and Windows, there is still a crash as the sample code tries to enumerate and run the prediction on all the files in the assets directory. That assets directory also has a wikimedia.md file which is not an image file. The ImageLoadingTransformer tries to load the wikimedia.md file as a bitmap which leads to a crash in System.Drawing.Bitmap constructor with a System.ArgumentException.

So, I have changed GetImagesData function to only enumerate the jpg files in the assets directory. 

This should fix the crash on both Windows and Mac. 