### PR TITLE
Fix PredictionEnginePool error in Azure Functions sample

### DIFF
--- a/samples/csharp/end-to-end-apps/ScalableMLModelOnAzureFunction/SentimentAnalysisFunctionsApp/Startup.cs
+++ b/samples/csharp/end-to-end-apps/ScalableMLModelOnAzureFunction/SentimentAnalysisFunctionsApp/Startup.cs
@@ -11,7 +11,7 @@ namespace SentimentAnalysisFunctionsApp
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder.Services.AddPredictionEnginePool<SentimentData, SentimentPrediction>()
-                .FromFile(modelName: "SentimentModel", filePath:"MLModels/sentiment_model.zip", watchForChanges: true);
+                .FromFile("MLModels/sentiment_model.zip");
         }
     }
 }


### PR DESCRIPTION
Adding model reloading throws the following error. Reverting to the original version of the sample without model reload.

```text
System.Private.CoreLib: Exception while executing function: AnalyzeSentiment. Microsoft.Extensions.ML: You need to configure a default, not named, model before you use this method.
```