### PR TITLE
Save the model to disk earlier - address issue #684

### DIFF
--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Training/ImageClassification.Train/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Training/ImageClassification.Train/Program.cs
@@ -69,12 +69,12 @@ namespace ImageClassification.Train
             // 5. Get the quality metrics (accuracy, etc.)
             EvaluateModel(mlContext, testDataView, trainedModel);
 
-            // 6. Try a single prediction simulating an end-user app
-            TrySinglePrediction(imagesForPredictions, mlContext, trainedModel);
-
-            // 7. Save the model to assets/outputs (You get ML.NET .zip model file and TensorFlow .pb model file)
+            // 6. Save the model to assets/outputs (You get ML.NET .zip model file and TensorFlow .pb model file)
             mlContext.Model.Save(trainedModel, trainDataView.Schema, outputMlNetModelFilePath);
             Console.WriteLine($"Model saved to: {outputMlNetModelFilePath}");
+
+            // 7. Try a single prediction simulating an end-user app
+            TrySinglePrediction(imagesForPredictions, mlContext, trainedModel);
 
             Console.WriteLine("Press any key to finish");
             Console.ReadKey();


### PR DESCRIPTION
This pull request addresses issue #684 - the model is now saved to disk before it's tested with images that aren't in the training set. This means that if there's any exception during that test, we won't all the work done in model generation/evaluation because it has been saved to disk already, and can be re-used.

Hope this helps,
Jeremy