### PR TITLE
Update Image Classification Sample to 1.4

### DIFF
--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/.gitignore
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/.gitignore
@@ -1,2 +1,4 @@
 **/assets/UD
 **/assets/CD
+**/workspace/*
+!**/workspace/README.md

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary.csproj
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary.csproj
@@ -6,9 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.4.0-preview2" />
-    <PackageReference Include="Microsoft.ML.Dnn" Version="0.16.0-preview2" />
-    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.4.0-preview2" />
+    <PackageReference Include="Microsoft.ML" Version="1.4.0" />
+    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.4.0" />
+    <PackageReference Include="Microsoft.ML.Vision" Version="1.4.0" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary.csproj
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.4.0" />
-    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.4.0" />
-    <PackageReference Include="Microsoft.ML.Vision" Version="1.4.0" />
+    <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="$(MicrosoftMLVersion)" />
+    <PackageReference Include="Microsoft.ML.Vision" Version="$(MicrosoftMLVersion)" />
     <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.15.0" />
   </ItemGroup>
 

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/Program.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.IO;
 using Microsoft.ML;
 using static Microsoft.ML.DataOperationsCatalog;
-using Microsoft.ML.Transforms;
+using Microsoft.ML.Vision;
 
 namespace DeepLearning_ImageClassification_Binary
 {
@@ -26,10 +26,9 @@ namespace DeepLearning_ImageClassification_Binary
             var preprocessingPipeline = mlContext.Transforms.Conversion.MapValueToKey(
                     inputColumnName: "Label",
                     outputColumnName: "LabelAsKey")
-                .Append(mlContext.Transforms.LoadImages(
+                .Append(mlContext.Transforms.LoadRawImageBytes(
                     outputColumnName: "Image",
                     imageFolder: assetsRelativePath,
-                    useImageType: false,
                     inputColumnName: "ImagePath"));
 
             IDataView preProcessedData = preprocessingPipeline
@@ -43,18 +42,19 @@ namespace DeepLearning_ImageClassification_Binary
             IDataView validationSet = validationTestSplit.TrainSet;
             IDataView testSet = validationTestSplit.TestSet;
 
-            var trainingPipeline = mlContext.Model.ImageClassification(
-                    featuresColumnName: "Image",
-                    labelColumnName: "LabelAsKey",
-                    arch: ImageClassificationEstimator.Architecture.ResnetV2101,
-                    epoch: 100,
-                    batchSize: 20,
-                    testOnTrainSet: false,
-                    metricsCallback: (metrics) => Console.WriteLine(metrics),
-                    validationSet: validationSet,
-                    reuseTrainSetBottleneckCachedValues: true,
-                    reuseValidationSetBottleneckCachedValues: true,
-                    disableEarlyStopping: false)
+            var classifierOptions = new ImageClassificationTrainer.Options()
+            {
+                FeatureColumnName = "Image",
+                LabelColumnName = "LabelAsKey",
+                ValidationSet = validationSet,
+                Arch = ImageClassificationTrainer.Architecture.ResnetV2101,
+                MetricsCallback = (metrics) => Console.WriteLine(metrics),
+                TestOnTrainSet = false,
+                ReuseTrainSetBottleneckCachedValues = true,
+                ReuseValidationSetBottleneckCachedValues = true,
+            };
+
+            var trainingPipeline = mlContext.MulticlassClassification.Trainers.ImageClassification(classifierOptions)
                 .Append(mlContext.Transforms.Conversion.MapKeyToValue("PredictedLabel"));
 
             ITransformer trainedModel = trainingPipeline.Fit(trainSet);

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/Program.cs
@@ -13,6 +13,7 @@ namespace DeepLearning_ImageClassification_Binary
         static void Main(string[] args)
         {
             var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../"));
+            var workspaceRelativePath = Path.Combine(projectDirectory, "workspace");
             var assetsRelativePath = Path.Combine(projectDirectory, "assets");
 
             MLContext mlContext = new MLContext();
@@ -52,6 +53,7 @@ namespace DeepLearning_ImageClassification_Binary
                 TestOnTrainSet = false,
                 ReuseTrainSetBottleneckCachedValues = true,
                 ReuseValidationSetBottleneckCachedValues = true,
+                WorkspacePath=workspaceRelativePath
             };
 
             var trainingPipeline = mlContext.MulticlassClassification.Trainers.ImageClassification(classifierOptions)

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/workspace/README.md
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification_Binary/workspace/README.md
@@ -1,0 +1,1 @@
+﻿Computed bottleneck values and trained TensorFlow model are stored in this directory.

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/README.md
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/README.md
@@ -173,6 +173,7 @@ var classifierOptions = new ImageClassificationTrainer.Options()
     TestOnTrainSet = false,
     ReuseTrainSetBottleneckCachedValues = true,
     ReuseValidationSetBottleneckCachedValues = true,
+    WorkspacePath=workspaceRelativePath
 };
 
 var trainingPipeline = mlContext.MulticlassClassification.Trainers.ImageClassification(classifierOptions)

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/README.md
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/README.md
@@ -133,13 +133,12 @@ IDataView shuffledData = mlContext.Data.ShuffleRows(imageData);
 
 ```csharp
 var preprocessingPipeline = mlContext.Transforms.Conversion.MapValueToKey(
-        inputColumnName:"Label",
-        outputColumnName:"LabelAsKey")
-    .Append(mlContext.Transforms.LoadImages(
-        outputColumnName:"Image", 
+        inputColumnName: "Label",
+        outputColumnName: "LabelAsKey")
+    .Append(mlContext.Transforms.LoadRawImageBytes(
+        outputColumnName: "Image",
         imageFolder: assetsRelativePath,
-        useImageType: false,
-        inputColumnName:"ImagePath"));
+        inputColumnName: "ImagePath"));
 ```
 
 1. Fit the data to the preprocessing pipeline.
@@ -164,18 +163,19 @@ IDataView testSet = validationTestSplit.TestSet;
 ## Define the training pipeline
 
 ```csharp
-var trainingPipeline = mlContext.Model.ImageClassification(
-        featuresColumnName: "Image",
-        labelColumnName: "LabelAsKey",
-        arch: ImageClassificationEstimator.Architecture.ResnetV2101,
-        epoch: 100,
-        batchSize: 20,
-        testOnTrainSet: false,
-        metricsCallback: (metrics) => Console.WriteLine(metrics),
-        validationSet: validationSet,
-        reuseTrainSetBottleneckCachedValues: true,
-        reuseValidationSetBottleneckCachedValues: true,
-        disableEarlyStopping:false)
+var classifierOptions = new ImageClassificationTrainer.Options()
+{
+    FeatureColumnName = "Image",
+    LabelColumnName = "LabelAsKey",
+    ValidationSet = validationSet,
+    Arch = ImageClassificationTrainer.Architecture.ResnetV2101,
+    MetricsCallback = (metrics) => Console.WriteLine(metrics),
+    TestOnTrainSet = false,
+    ReuseTrainSetBottleneckCachedValues = true,
+    ReuseValidationSetBottleneckCachedValues = true,
+};
+
+var trainingPipeline = mlContext.MulticlassClassification.Trainers.ImageClassification(classifierOptions)
     .Append(mlContext.Transforms.Conversion.MapKeyToValue("PredictedLabel"));
 ```
 
@@ -254,10 +254,10 @@ Run your console app. The output should be similar to that below. You may see wa
 ### Bottleneck phase
 
 ```text
-Phase: Bottleneck Computation, Dataset used:      Train, Image Index: 279, Image Name:
-Phase: Bottleneck Computation, Dataset used:      Train, Image Index: 280, Image Name:
-Phase: Bottleneck Computation, Dataset used: Validation, Image Index:   1, Image Name:
-Phase: Bottleneck Computation, Dataset used: Validation, Image Index:   2, Image Name:
+Phase: Bottleneck Computation, Dataset used:      Train, Image Index: 279
+Phase: Bottleneck Computation, Dataset used:      Train, Image Index: 280
+Phase: Bottleneck Computation, Dataset used: Validation, Image Index:   1
+Phase: Bottleneck Computation, Dataset used: Validation, Image Index:   2
 ```
 
 ### Training phase


### PR DESCRIPTION
- Updated preprocessing pipeline to use `LoadRawImageBytes`.
- Updated training pipeline to use `ImageClassificationTrainer.Options` to set parameters.

To-do:

- [x] Enable reuse of bottleneck values. This is pending dotnet/machinelearning#4452
- [x] Update Docs tutorial