### PR TITLE
Add NuGet version hint

### DIFF
--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Training/README.md
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Training/README.md
@@ -50,11 +50,13 @@ To solve this problem, first we will build an ML model. Then we will train the m
 By default this solution uses **CPU** for training and scoring.
 But if your machine has a compatible **GPU** available (basically most NVIDIA GPU graphics cards), you can configure the project to use GPU.
 
+> :warning: Make sure you use the correct versions of the NuGet packages listed below. Other versions might be incompatiple with Nvidia CUDA v10.0
+
 #### Using CPU for training or inference/scoring
 
 When using **CPU**, your project has to reference the following redist library:
 
-- `SciSharp.TensorFlow.Redist` (CPU training)
+- `SciSharp.TensorFlow.Redist (1.15.0)` (CPU training)
 
 Sample references screenshot in training project using **CPU**:
 
@@ -64,9 +66,9 @@ Sample references screenshot in training project using **CPU**:
 
 When using **GPU**, your project has to reference the following redist library (*and remove the CPU version reference*):
 
-- `SciSharp.TensorFlow.Redist-Windows-GPU` (GPU training on Windows) 
+- `SciSharp.TensorFlow.Redist-Windows-GPU (1.14.0)` (GPU training on Windows) 
 
-- `SciSharp.TensorFlow.Redist-Linux-GPU` (GPU training on Linux)
+- `SciSharp.TensorFlow.Redist-Linux-GPU (1.14.0)` (GPU training on Linux)
 
 Sample references screenshot in training project using **GPU**:
 


### PR DESCRIPTION
I wanted to use GPU support inside the sample project and added a reference to `SciSharp.TensorFlow.Redist-Windows-GPU` and removed the `SciSharp.TensorFlow.Redist`. By mistake i used  `SciSharp.TensorFlow.Redist-Windows-GPU` `v.2.3.0` and i ended up in a console warning telling me that the framework is falling back to CPU computing:
```
W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'cudart64_101.dll'; dlerror: cudart64_101.dll not found
```

Seems that the newer NuGet packages are not compatiple with the mentioned setup [here](https://github.com/dotnet/machinelearning/blob/master/docs/api-reference/tensorflow-usage.md#prerequisites) where CUDA v10.0 and CUDNN v7.6.4 is to be installed.

The PR explicitly adds a note on the NuGet package.