### PR TITLE
Minor edits to the DeepLearning Binary classification sample

### DIFF
--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification/DeepLearning_ImageClassification.csproj
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification/DeepLearning_ImageClassification.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="$(MicrosoftMLVersion)" />
     <PackageReference Include="Microsoft.ML.Vision" Version="$(MicrosoftMLVersion)" />
     <PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.3.0" />
+    <PackageReference Condition="'$(TargetFramework)'=='netcoreapp2.1'" Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification/Program.cs
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification/Program.cs
@@ -53,8 +53,7 @@ namespace DeepLearning_ImageClassification
                 MetricsCallback = (metrics) => Console.WriteLine(metrics),
                 TestOnTrainSet = false,
                 ReuseTrainSetBottleneckCachedValues = true,
-                ReuseValidationSetBottleneckCachedValues = true,
-                WorkspacePath=workspaceRelativePath
+                ReuseValidationSetBottleneckCachedValues = true
             };
 
             var trainingPipeline = mlContext.MulticlassClassification.Trainers.ImageClassification(classifierOptions)

--- a/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/README.md
+++ b/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/README.md
@@ -19,6 +19,8 @@ products:
 
 For a detailed explanation of how to build this application, see the accompanying [tutorial](https://docs.microsoft.com/en-us/dotnet/machine-learning/tutorials/image-classification-api-transfer-learning) on the Microsoft Docs site.
 
+This sample may be downloaded and built directly. However, for a succesful run, you **must** first unzip *assets.zip* in the project directory, and copy its subdirectories into the *assets* directory.
+
 ## Understanding the problem
 
 Image classification is a computer vision problem. Image classification takes an image as input and categorizes it into a prescribed class. This sample shows a .NET Core console application that trains a custom deep learning model using transfer learning, a pretrained image classification TensorFlow model and the ML.NET Image Classification API to classify images of concrete surfaces into one of two categories, cracked or uncracked.


### PR DESCRIPTION
This `DeepLearning_ImageClassification_Binary` sample requires that `assets.zip` be first unpacked into its intended `\assets` destination.

In addition, the `WorkspacePath` given to the `ImageClassification.Options` to indicates the path where the TensorFlow image bottleneck cache files and trained model are saved may be a path longer than 255 chars, which is [the maximum path length supported by the Windows shell ](https://stackoverflow.com/questions/1857335/is-there-any-length-limits-of-file-path-in-ntfs). If the path is longer than this, a TF Saver errors occurs (as detailed in this [issue](https://github.com/una-dinosauria/human-motion-prediction/issues/10)) where TensorFlow's Saver.save method fails to create the checkpoint file. Given that the sample's path is already long in this repo, and is likely to be even longer when downloaded locally, it is best to use a  shallower temporary directory. The [default value](https://docs.microsoft.com/en-us/dotnet/api/microsoft.ml.vision.imageclassificationtrainer.options.workspacepath?view=ml-dotnet) of `WorkspacePath` is just this temp folder.

Also added the NuGet `System.Runtime.CompilerServices.Unsafe`, which is needed when loading `ImageClassificationTrainer.Architecture.ResnetV2101` on .NET Core 2.1.