### PR TITLE
TensorFlow Estimator: Upgrade .NET

### DIFF
--- a/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Predict/ImageClassification.Predict.csproj
+++ b/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Predict/ImageClassification.Predict.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Train/ImageClassification.Train.csproj
+++ b/samples/csharp/getting-started/DeepLearning_TensorFlowEstimator/ImageClassification.Train/ImageClassification.Train.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.2</LangVersion>
     <StartupObject />
   </PropertyGroup>


### PR DESCRIPTION
Seems to have no problem upgrading to .NET 7 from 2.1